### PR TITLE
2019 10 01 script program cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,8 @@ matrix:
         - TEST_COMMAND="walletTest/test wallet/coverageReport wallet/coverageAggregate wallet/coveralls"
       scala:
         - 2.13.0
+    # skip all test tagged as UsesExperimentalBitcoind
+    # TODO remove this condition once we have a neutrino enabled bitcoind binary for OSX
     - os: osx
       name: "macOS node tests"
       env:
@@ -110,5 +112,4 @@ stages:
 
 script:
   # Modify PATH to include binaries we are about to download
-  - export PATH=$PWD/binaries/bitcoind/bitcoin-0.17.0/bin/:$PATH
   - sbt ++$TRAVIS_SCALA_VERSION downloadBitcoind downloadEclair coverage $TEST_COMMAND

--- a/app/server/src/main/resources/reference.conf
+++ b/app/server/src/main/resources/reference.conf
@@ -1,3 +1,65 @@
+bitcoin-s {
+    datadir = ${HOME}/.bitcoin-s
+    network = regtest # regtest, testnet3, mainnet
+
+    logging {
+        level = WARN # trace, debug, info, warn, error, off
+
+        # You can also tune specific module loggers.
+        # They each take the same levels as above.
+        # If they are commented out (as they are
+        # by default), `logging.level` gets used
+        # instead.
+        # The available loggers are:
+
+        # incoming and outgoing P2P messages
+        # p2p = info
+
+        # verification of block headers, merkle trees
+        # chain-verification = info
+
+        # generation of addresses, signing of TXs
+        # key-handling = info
+
+        # wallet operations not related to key management
+        # wallet = info
+
+        # HTTP RPC server
+        # http = info
+
+        # Database interactions
+        # database = info
+
+        # whether or not to write to the log file
+        disable-file = false
+
+        # whether or not to log to stdout
+        disable-console = false
+    }
+
+    node {
+        peers = ["localhost"] # a list of peer addresses in form "hostname:portnumber"
+                              # (e.g. "neutrino.testnet3.suredbits.com:18333")
+                              # Port number is optional, the default value is 8333 for mainnet,
+                              # 18333 for testnet and 18444 for regtest.
+        mode = neutrino # neutrino, spv
+    }
+
+    chain {
+        neutrino {
+            filter-header-batch-size = 2000
+            filter-batch-size = 100
+        }
+    }
+
+    # settings for wallet module
+    wallet {
+        defaultAccountType = legacy # legacy, segwit, nested-segwit
+
+        bloomFalsePositiveRate = 0.0001 # percentage
+    }
+}
+
 akka {
 
     loglevel = "INFO"

--- a/app/server/src/main/scala/org/bitcoins/server/Main.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/Main.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.server
 
+import java.net.InetSocketAddress
 import java.nio.file.Files
 
 import akka.actor.ActorSystem
@@ -69,20 +70,11 @@ object Main extends App {
     }
   }
 
-  val bitcoind = BitcoindInstance.fromDatadir()
-  val bitcoindCli = BitcoindRpcClient.withActorSystem(bitcoind)
-  val peer = Peer.fromBitcoind(bitcoind)
+  val peerSocket =
+    parseInetSocketAddress(nodeConf.peers.head, nodeConf.network.port)
+  val peer = Peer.fromSocket(peerSocket)
 
   val startFut = for {
-    _ <- bitcoindCli.isStartedF.map { started =>
-      if (!started) error("Local bitcoind is not started!")
-    }
-    _ <- bitcoindCli.getBlockChainInfo.map { bitcoindInfo =>
-      if (bitcoindInfo.chain != nodeConf.network)
-        error(
-          s"bitcoind and Bitcoin-S node are on different chains! Bitcoind: ${bitcoindInfo.chain}. Bitcoin-S node: ${nodeConf.network}")
-    }
-
     _ <- conf.initialize()
     wallet <- walletInitF
 
@@ -141,5 +133,30 @@ object Main extends App {
 
   startFut.failed.foreach { err =>
     logger.info(s"Error on server startup!", err)
+  }
+
+  private def parseInetSocketAddress(
+      address: String,
+      defaultPort: Int): InetSocketAddress = {
+
+    def parsePort(port: String): Int = {
+      lazy val errorMsg = s"Invalid peer port: $address"
+      try {
+        val res = port.toInt
+        if (res < 0 || res > 0xffff) {
+          throw new RuntimeException(errorMsg)
+        }
+        res
+      } catch {
+        case _: NumberFormatException =>
+          throw new RuntimeException(errorMsg)
+      }
+    }
+
+    address.split(":") match {
+      case Array(host)       => new InetSocketAddress(host, defaultPort)
+      case Array(host, port) => new InetSocketAddress(host, parsePort(port))
+      case _                 => throw new RuntimeException(s"Invalid peer address: $address")
+    }
   }
 }

--- a/app/server/src/main/scala/org/bitcoins/server/Main.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/Main.scala
@@ -9,8 +9,6 @@ import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.models.Peer
 import org.bitcoins.node.networking.peer.DataMessageHandler
 import org.bitcoins.node.{NeutrinoNode, SpvNode, SpvNodeCallbacks}
-import org.bitcoins.rpc.client.common.BitcoindRpcClient
-import org.bitcoins.rpc.config.BitcoindInstance
 import org.bitcoins.wallet.api._
 import org.bitcoins.wallet.config.WalletAppConfig
 import org.bitcoins.wallet.{LockedWallet, Wallet, WalletStorage}

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/BitcoindInstanceTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/BitcoindInstanceTest.scala
@@ -1,24 +1,25 @@
 package org.bitcoins.rpc
 import java.io.{File, PrintWriter}
+import java.net.URI
 import java.nio.file.{Files, Path}
 
+import akka.stream.StreamTcpException
+import org.bitcoins.core.config.RegTest
 import org.bitcoins.core.currency.Bitcoins
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
-import org.bitcoins.rpc.config.BitcoindInstance
-import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
-import org.bitcoins.testkit.util.BitcoindRpcTest
-
-import scala.io.Source
-import akka.stream.StreamTcpException
-import java.nio.file.Paths
-import scala.util.Properties
-import org.bitcoins.rpc.config.BitcoindConfig
-import org.bitcoins.rpc.config.BitcoindAuthCredentials
+import org.bitcoins.rpc.config.{
+  BitcoindAuthCredentials,
+  BitcoindConfig,
+  BitcoindInstance
+}
 import org.bitcoins.rpc.util.RpcUtil
-import org.bitcoins.core.config.RegTest
-import java.net.URI
-import scala.concurrent.Future
+import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
+import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil.newestBitcoindBinary
+import org.bitcoins.testkit.util.BitcoindRpcTest
 import org.scalatest.compatible.Assertion
+
+import scala.concurrent.Future
+import scala.io.Source
 
 class BitcoindInstanceTest extends BitcoindRpcTest {
 
@@ -65,7 +66,7 @@ class BitcoindInstanceTest extends BitcoindRpcTest {
     """.stripMargin
 
     val conf = BitcoindConfig(confStr, BitcoindRpcTestUtil.tmpDir())
-    val instance = BitcoindInstance.fromConfig(conf)
+    val instance = BitcoindInstance.fromConfig(conf, newestBitcoindBinary)
     assert(
       instance.authCredentials
         .isInstanceOf[BitcoindAuthCredentials.CookieBased])
@@ -85,7 +86,7 @@ class BitcoindInstanceTest extends BitcoindRpcTest {
       """.stripMargin
 
     val conf = BitcoindConfig(confStr, BitcoindRpcTestUtil.tmpDir())
-    val instance = BitcoindInstance.fromConfig(conf)
+    val instance = BitcoindInstance.fromConfig(conf, newestBitcoindBinary)
     assert(
       instance.authCredentials
         .isInstanceOf[BitcoindAuthCredentials.PasswordBased])
@@ -121,14 +122,16 @@ class BitcoindInstanceTest extends BitcoindRpcTest {
         uri = new URI(s"http://localhost:$port"),
         rpcUri = new URI(s"http://localhost:$rpcPort"),
         authCredentials = authCredentials,
-        datadir = conf.datadir
+        datadir = conf.datadir,
+        binary = newestBitcoindBinary
       )
 
     testClientStart(BitcoindRpcClient.withActorSystem(instance))
   }
 
   it should "parse a bitcoin.conf file, start bitcoind, mine some blocks and quit" in {
-    val instance = BitcoindInstance.fromDatadir(datadir.toFile)
+    val instance =
+      BitcoindInstance.fromDatadir(datadir.toFile, newestBitcoindBinary)
     val client = BitcoindRpcClient.withActorSystem(instance)
 
     for {

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/TestRpcUtilTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/TestRpcUtilTest.scala
@@ -4,7 +4,6 @@ import java.io.File
 
 import org.bitcoins.core.currency.Bitcoins
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
-import org.bitcoins.rpc.client.common.RpcOpts.AddNodeArgument
 import org.bitcoins.rpc.util.AsyncUtil.RpcRetryException
 import org.bitcoins.rpc.util.{AsyncUtil, RpcUtil}
 import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/BlockchainRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/BlockchainRpcTest.scala
@@ -2,7 +2,7 @@ package org.bitcoins.rpc.common
 
 import org.bitcoins.core.currency.Bitcoins
 import org.bitcoins.core.number.UInt32
-import org.bitcoins.rpc.client.common.BitcoindRpcClient
+import org.bitcoins.rpc.client.common.{BitcoindRpcClient, BitcoindVersion}
 import org.bitcoins.rpc.client.common.RpcOpts.{AddNodeArgument, AddressType}
 import org.bitcoins.rpc.util.AsyncUtil
 import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
@@ -14,13 +14,14 @@ import org.bitcoins.core.config.RegTest
 class BlockchainRpcTest extends BitcoindRpcTest {
 
   lazy val clientsF: Future[(BitcoindRpcClient, BitcoindRpcClient)] =
-    BitcoindRpcTestUtil.createNodePair(clientAccum = clientAccum)
+    BitcoindRpcTestUtil.createNodePairV17(clientAccum = clientAccum)
 
   lazy val pruneClientF: Future[BitcoindRpcClient] = clientsF.flatMap {
     case (_, _) =>
       val pruneClient =
         BitcoindRpcClient.withActorSystem(
-          BitcoindRpcTestUtil.instance(pruneMode = true))
+          BitcoindRpcTestUtil.instance(pruneMode = true,
+                                       versionOpt = Some(BitcoindVersion.V17)))
 
       clientAccum += pruneClient
 

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/MempoolRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/MempoolRpcTest.scala
@@ -1,9 +1,7 @@
 package org.bitcoins.rpc.common
 
 import java.io.File
-import java.nio.file.Files
 
-import com.typesafe.config.ConfigValueFactory
 import org.bitcoins.core.currency.Bitcoins
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.script.ScriptSignature
@@ -17,11 +15,10 @@ import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
 import org.bitcoins.testkit.util.BitcoindRpcTest
 
 import scala.concurrent.Future
-import java.nio.file.Path
 
 class MempoolRpcTest extends BitcoindRpcTest {
   lazy val clientsF: Future[(BitcoindRpcClient, BitcoindRpcClient)] =
-    BitcoindRpcTestUtil.createNodePair(clientAccum = clientAccum)
+    BitcoindRpcTestUtil.createNodePairV18(clientAccum = clientAccum)
 
   lazy val clientWithoutBroadcastF: Future[BitcoindRpcClient] =
     clientsF.flatMap {
@@ -33,7 +30,8 @@ class MempoolRpcTest extends BitcoindRpcTest {
             .withOption("walletbroadcast", 0.toString)
 
         val instanceWithoutBroadcast =
-          BitcoindInstance.fromConfig(configNoBroadcast)
+          BitcoindInstance.fromConfig(configNoBroadcast,
+                                      BitcoindRpcTestUtil.newestBitcoindBinary)
 
         val clientWithoutBroadcast =
           BitcoindRpcClient.withActorSystem(instanceWithoutBroadcast)

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/MiningRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/MiningRpcTest.scala
@@ -9,7 +9,7 @@ import org.bitcoins.rpc.BitcoindP2PException.NotConnected
 
 class MiningRpcTest extends BitcoindRpcTest {
   lazy val clientsF: Future[(BitcoindRpcClient, BitcoindRpcClient)] =
-    BitcoindRpcTestUtil.createNodePair(clientAccum = clientAccum)
+    BitcoindRpcTestUtil.createNodePairV17(clientAccum = clientAccum)
 
   behavior of "MiningRpc"
 

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/RawTransactionRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/RawTransactionRpcTest.scala
@@ -20,7 +20,7 @@ import org.bitcoins.rpc.BitcoindException.InvalidAddressOrKey
 
 class RawTransactionRpcTest extends BitcoindRpcTest {
   lazy val clientsF: Future[(BitcoindRpcClient, BitcoindRpcClient)] =
-    BitcoindRpcTestUtil.createNodePair(clientAccum = clientAccum)
+    BitcoindRpcTestUtil.createNodePairV17(clientAccum = clientAccum)
 
   behavior of "RawTransactionRpc"
 

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/WalletRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/WalletRpcTest.scala
@@ -33,7 +33,7 @@ import scala.concurrent.Future
 class WalletRpcTest extends BitcoindRpcTest {
   lazy val clientsF: Future[
     (BitcoindRpcClient, BitcoindRpcClient, BitcoindRpcClient)] =
-    BitcoindRpcTestUtil.createNodeTriple(clientAccum = clientAccum)
+    BitcoindRpcTestUtil.createNodeTripleV17(clientAccum = clientAccum)
 
   // This client's wallet is encrypted
   lazy val walletClientF: Future[BitcoindRpcClient] = clientsF.flatMap { _ =>

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
@@ -75,8 +75,9 @@ object BitcoindRpcClient {
     * the default datadir if no directory is provided
     */
   def fromDatadir(
-      datadir: File = BitcoindConfig.DEFAULT_DATADIR): BitcoindRpcClient = {
-    val instance = BitcoindInstance.fromDatadir(datadir)
+      datadir: File = BitcoindConfig.DEFAULT_DATADIR,
+      binary: File): BitcoindRpcClient = {
+    val instance = BitcoindInstance.fromDatadir(datadir, binary)
     val cli = BitcoindRpcClient(instance)
     cli
   }

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindInstance.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindInstance.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.rpc.config
 
-import java.io.File
+import java.io.{File, FileNotFoundException}
 import java.net.URI
 import java.nio.file.{Files, Paths}
 
@@ -9,7 +9,6 @@ import org.bitcoins.core.util.BitcoinSLogger
 import org.bitcoins.rpc.client.common.BitcoindVersion
 
 import scala.sys.process._
-
 import org.bitcoins.core.util.BitcoinSLogger
 import org.bitcoins.core.config.NetworkParameters
 
@@ -51,6 +50,9 @@ sealed trait BitcoindInstance extends BitcoinSLogger {
         .last
 
     foundVersion match {
+      case _: String
+          if foundVersion.equals(BitcoindVersion.Experimental.toString) =>
+        BitcoindVersion.Experimental
       case _: String if foundVersion.startsWith(BitcoindVersion.V16.toString) =>
         BitcoindVersion.V16
       case _: String if foundVersion.startsWith(BitcoindVersion.V17.toString) =>
@@ -95,16 +97,22 @@ object BitcoindInstance {
 
   lazy val DEFAULT_BITCOIND_LOCATION: File = {
 
+    def findExecutableOnPath(name: String): Option[File] =
+      sys.env
+        .getOrElse("PATH", "")
+        .split(File.pathSeparator)
+        .map(directory => new File(directory, name))
+        .find(file => file.isFile && file.canExecute)
+
     val cmd =
       if (Properties.isWin) {
-        "which bitcoind.exe".!!
+        findExecutableOnPath("bitcoind.exe")
       } else {
-        "which bitcoind".!!
+        findExecutableOnPath("bitcoind")
       }
 
-    val path = cmd
-    new File(path.trim)
-
+    cmd.getOrElse(
+      throw new FileNotFoundException("Cannot find a path to bitcoind"))
   }
 
   /** Constructs a `bitcoind` instance from the given datadir, using the
@@ -113,7 +121,9 @@ object BitcoindInstance {
     * @throws IllegalArgumentException if the given datadir does not exist
     */
   def fromDatadir(
-      datadir: File = BitcoindConfig.DEFAULT_DATADIR): BitcoindInstance = {
+      datadir: File = BitcoindConfig.DEFAULT_DATADIR,
+      binary: File = DEFAULT_BITCOIND_LOCATION
+  ): BitcoindInstance = {
     require(datadir.exists, s"${datadir.getPath} does not exist!")
     require(datadir.isDirectory, s"${datadir.getPath} is not a directory!")
 
@@ -121,9 +131,9 @@ object BitcoindInstance {
     if (Files.exists(configPath)) {
 
       val file = configPath.toFile()
-      fromConfigFile(file)
+      fromConfigFile(file, binary)
     } else {
-      fromConfig(BitcoindConfig.empty)
+      fromConfig(BitcoindConfig.empty, binary)
     }
   }
 
@@ -134,18 +144,21 @@ object BitcoindInstance {
     * @throws  IllegalArgumentException if the given config file does not exist
     */
   def fromConfigFile(
-      file: File = BitcoindConfig.DEFAULT_CONF_FILE): BitcoindInstance = {
+      file: File = BitcoindConfig.DEFAULT_CONF_FILE,
+      binary: File = DEFAULT_BITCOIND_LOCATION
+  ): BitcoindInstance = {
     require(file.exists, s"${file.getPath} does not exist!")
     require(file.isFile, s"${file.getPath} is not a file!")
 
     val conf = BitcoindConfig(file, file.getParentFile)
 
-    fromConfig(conf)
+    fromConfig(conf, binary)
   }
 
   /** Constructs a `bitcoind` instance from the given config */
   def fromConfig(
-      config: BitcoindConfig
+      config: BitcoindConfig,
+      binary: File = DEFAULT_BITCOIND_LOCATION
   ): BitcoindInstance = {
 
     val authCredentials = BitcoindAuthCredentials.fromConfig(config)
@@ -154,6 +167,7 @@ object BitcoindInstance {
                      config.rpcUri,
                      authCredentials,
                      zmqConfig = ZmqConfig.fromConfig(config),
+                     binary = binary,
                      datadir = config.datadir)
   }
 }

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -74,6 +74,10 @@ case class ChainHandler(
     val newChainHandler = this.copy(blockchains = chains)
 
     createdF.map { _ =>
+      chains.foreach { c =>
+        logger.info(
+          s"Processed headers from height=${c(headers.length - 1).height} to ${c.height}. Best hash=${c.tip.hashBE.hex}")
+      }
       newChainHandler
     }
   }

--- a/core-test/src/test/scala/org/bitcoins/core/gcs/GCSTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/gcs/GCSTest.scala
@@ -189,7 +189,7 @@ class GCSTest extends BitcoinSUnitTest {
 
     def items: Gen[(Vector[UInt64], UInt8)] = {
       NumberGenerator.genP.flatMap { p =>
-        Gen.choose(1, 500).flatMap { size =>
+        Gen.choose(1, 250).flatMap { size =>
           // If hash's quotient when divided by 2^p is too large, we hang converting to unary
           val upperBound: Long = 1L << (p.toInt * 1.75).toInt
 

--- a/core-test/src/test/scala/org/bitcoins/core/p2p/NetworkMessageTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/p2p/NetworkMessageTest.scala
@@ -9,4 +9,21 @@ class NetworkMessageTest extends BitcoinSUnitTest {
     NetworkMessage(NodeTestUtil.rawNetworkMessage).hex must be(
       NodeTestUtil.rawNetworkMessage)
   }
+
+
+  it must "serialize and deserialize a version message example from the bitcoin wiki" in {
+    val hex = {
+      //taken from here with slight modifications
+      //https://en.bitcoin.it/wiki/Protocol_documentation#Message_structure
+      //this example uses an old protocol version WITHOUT the relay flag on the version message
+      //since we only support protocol version > 7, i added it manually
+      //this means the payload size is bumped by 1 byte in the NetworkHeader from 100 -> 101
+      //and a relay byte "00" is appended to the end of the payload
+      "F9BEB4D976657273696F6E000000000065000000358d4932" +
+        "62EA0000010000000000000011B2D05000000000010000000000000000000000000000000000FFFF000000000000010000000000000000000000000000000000FFFF0000000000003B2EB35D8CE617650F2F5361746F7368693A302E372E322FC03E0300" +
+        "00"
+    }.toLowerCase
+    val networkMsg = NetworkMessage.fromHex(hex)
+    networkMsg.hex must be (hex)
+  }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/script/ScriptProgramFactoryTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/ScriptProgramFactoryTest.scala
@@ -20,11 +20,15 @@ class ScriptProgramFactoryTest extends FlatSpec with MustMatchers {
     val altStack = List(OP_1)
 
     val modifiedStackProgram =
-      ScriptProgram(TestUtil.testProgram, stack, ScriptProgram.Stack)
+      ScriptProgram(TestUtil.testProgramExecutionInProgress,
+                    stack,
+                    ScriptProgram.Stack)
     modifiedStackProgram.stack must be(stack)
 
     val modifiedAltStack =
-      ScriptProgram(TestUtil.testProgram, altStack, ScriptProgram.AltStack)
+      ScriptProgram(TestUtil.testProgramExecutionInProgress,
+                    altStack,
+                    ScriptProgram.AltStack)
 
     modifiedAltStack.altStack must be(altStack)
   }

--- a/core-test/src/test/scala/org/bitcoins/core/script/ScriptProgramTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/ScriptProgramTest.scala
@@ -12,14 +12,16 @@ class ScriptProgramTest extends FlatSpec with MustMatchers {
   "ScriptProgram" must "determine if the stack top is true" in {
     val stack = List(ScriptNumber(1))
     val script = List()
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     program.stackTopIsTrue must be(true)
   }
 
   it must "determine if the stack stop is false" in {
     val stack = List(ScriptNumber.zero)
     val script = List()
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     program.stackTopIsTrue must be(false)
 
     val program2 = ScriptProgram(program, List(OP_0), ScriptProgram.Stack)

--- a/core-test/src/test/scala/org/bitcoins/core/script/arithmetic/ArithmeticInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/arithmetic/ArithmeticInterpreterTest.scala
@@ -23,7 +23,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   "ArithmeticInterpreter" must "perform an OP_ADD correctly" in {
     val stack = List(ScriptNumber.one, ScriptNumber(2))
     val script = List(OP_ADD)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.opAdd(program)
     newProgram.stack.head must be(ScriptNumber(3))
     newProgram.script.isEmpty must be(true)
@@ -32,7 +33,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "perform an OP_1ADD correctly" in {
     val stack = List(ScriptNumber.zero)
     val script = List(OP_1ADD)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.op1Add(program)
 
     newProgram.stack.head must be(ScriptNumber.one)
@@ -54,7 +56,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "perform an OP_1SUB corectly" in {
     val stack = List(ScriptNumber.zero)
     val script = List(OP_1SUB)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.op1Sub(program)
 
     newProgram.stack.head must be(ScriptNumber(-1))
@@ -75,7 +78,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "perform an OP_SUB corectly" in {
     val stack = List(ScriptNumber.one, ScriptNumber.zero)
     val script = List(OP_SUB)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.opSub(program)
 
     newProgram.stack.head must be(ScriptNumber(-1))
@@ -95,7 +99,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "perform an OP_ABS on a negative number corectly" in {
     val stack = List(ScriptNumber(-1))
     val script = List(OP_ABS)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.opAbs(program)
 
     newProgram.stack.head must be(ScriptNumber.one)
@@ -105,7 +110,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "perform OP_ABS on zero correctly" in {
     val stack = List(ScriptNumber.zero)
     val script = List(OP_ABS)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.opAbs(program)
 
     newProgram.stack.head must be(ScriptNumber.zero)
@@ -124,7 +130,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "perform an OP_NEGATE on a zero correctly" in {
     val stack = List(ScriptNumber.zero)
     val script = List(OP_NEGATE)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.opNegate(program)
 
     newProgram.stack.head must be(ScriptNumber.zero)
@@ -134,7 +141,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "perform an OP_NEGATE on a positive number correctly" in {
     val stack = List(ScriptNumber.one)
     val script = List(OP_NEGATE)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.opNegate(program)
 
     newProgram.stack.head must be(ScriptNumber(-1))
@@ -144,7 +152,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "perform an OP_NEGATE on a negative number correctly" in {
     val stack = List(ScriptNumber(-1))
     val script = List(OP_NEGATE)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.opNegate(program)
 
     newProgram.stack.head must be(ScriptNumber.one)
@@ -164,7 +173,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "perform an OP_NOT correctly where 0 is the stack top" in {
     val stack = List(ScriptNumber.zero)
     val script = List(OP_NOT)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.opNot(program)
 
     newProgram.stackTopIsTrue must be(true)
@@ -175,7 +185,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "perform an OP_NOT correctly where 1 is the stack top" in {
     val stack = List(ScriptNumber.one)
     val script = List(OP_NOT)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.opNot(program)
 
     newProgram.stackTopIsFalse must be(true)
@@ -186,7 +197,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "perform an OP_0NOTEQUAL correctly where 0 is the stack top" in {
     val stack = List(ScriptNumber.zero)
     val script = List(OP_0NOTEQUAL)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.op0NotEqual(program)
 
     newProgram.stack.head must be(OP_FALSE)
@@ -196,7 +208,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "perform an OP_0NOTEQUAL correctly where 1 is the stack top" in {
     val stack = List(ScriptNumber.one)
     val script = List(OP_0NOTEQUAL)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.op0NotEqual(program)
 
     newProgram.stack.head must be(OP_TRUE)
@@ -206,7 +219,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "have an OP_BOOLAND correctly for two 0s" in {
     val stack = List(ScriptNumber.zero, ScriptNumber.zero)
     val script = List(OP_BOOLAND)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.opBoolAnd(program)
 
     newProgram.stackTopIsFalse must be(true)
@@ -215,7 +229,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
 
     val stack1 = List(OP_0, OP_0)
     val script1 = List(OP_BOOLAND)
-    val program1 = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program1 =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram1 = AI.opBoolAnd(program)
 
     newProgram.stackTopIsFalse must be(true)
@@ -226,7 +241,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "have an OP_BOOLAND correctly for one 0" in {
     val stack = List(ScriptNumber.zero, OP_1)
     val script = List(OP_BOOLAND)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.opBoolAnd(program)
 
     newProgram.stackTopIsTrue must be(false)
@@ -237,7 +253,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "have an OP_BOOLOR correctly for two 1s" in {
     val stack = List(ScriptNumber.one, ScriptNumber.one)
     val script = List(OP_BOOLOR)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.opBoolOr(program)
 
     newProgram.stack.head must be(OP_TRUE)
@@ -247,7 +264,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "have an OP_BOOLOR correctly for two 0s" in {
     val stack = List(ScriptNumber.zero, ScriptNumber.zero)
     val script = List(OP_BOOLOR)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.opBoolOr(program)
 
     newProgram.stack.head must be(OP_FALSE)
@@ -257,7 +275,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "have an OP_BOOLOR correctly for one OP_0" in {
     val stack = List(ScriptNumber.zero, ScriptNumber.one)
     val script = List(OP_BOOLOR)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.opBoolOr(program)
 
     newProgram.stack.head must be(OP_TRUE)
@@ -267,7 +286,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "evaulate an OP_NUMEQUAL for two zeros" in {
     val stack = List(ScriptNumber.zero, ScriptNumber.zero)
     val script = List(OP_NUMEQUAL)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.opNumEqual(program)
 
     newProgram.stackTopIsTrue must be(true)
@@ -310,7 +330,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "evaluate an OP_NUMNOTEQUAL for two numbers that are the same" in {
     val stack = List(ScriptNumber.zero, ScriptNumber.zero)
     val script = List(OP_NUMNOTEQUAL)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.opNumNotEqual(program)
 
     newProgram.stack.head must be(OP_FALSE)
@@ -320,7 +341,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "evaluate an OP_NUMNOTEQUAL for two numbers that are not the same" in {
     val stack = List(ScriptNumber.zero, ScriptNumber.one)
     val script = List(OP_NUMNOTEQUAL)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.opNumNotEqual(program)
 
     newProgram.stack.head must be(OP_TRUE)
@@ -330,7 +352,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "evaluate an OP_LESSTHAN correctly" in {
     val stack = List(ScriptNumber.zero, ScriptNumber.one)
     val script = List(OP_LESSTHAN)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.opLessThan(program)
 
     newProgram.stack.head must be(OP_FALSE)
@@ -338,8 +361,9 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
 
     val stack1 = List(ScriptNumber.zero, ScriptNumber.zero)
     val script1 = List(OP_LESSTHAN)
-    ScriptProgram(TestUtil.testProgram, stack, script)
-    val program1 = ScriptProgram(TestUtil.testProgram, stack1, script1)
+    ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
+    val program1 =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack1, script1)
     val newProgram1 = AI.opLessThan(program1)
 
     newProgram1.stack.head must be(OP_FALSE)
@@ -347,7 +371,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
 
     val stack2 = List(ScriptNumber.one, ScriptNumber.zero)
     val script2 = List(OP_LESSTHAN)
-    val program2 = ScriptProgram(TestUtil.testProgram, stack2, script2)
+    val program2 =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack2, script2)
     val newProgram2 = AI.opLessThan(program2)
 
     newProgram2.stack.head must be(OP_TRUE)
@@ -357,7 +382,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "evaluate an OP_LESSTHANOREQUAL correctly" in {
     val stack = List(ScriptNumber.zero, ScriptNumber.one)
     val script = List(OP_LESSTHANOREQUAL)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.opLessThanOrEqual(program)
 
     newProgram.stack.head must be(OP_FALSE)
@@ -365,8 +391,9 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
 
     val stack1 = List(ScriptNumber.zero, ScriptNumber.zero)
     val script1 = List(OP_LESSTHANOREQUAL)
-    ScriptProgram(TestUtil.testProgram, stack, script)
-    val program1 = ScriptProgram(TestUtil.testProgram, stack1, script1)
+    ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
+    val program1 =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack1, script1)
     val newProgram1 = AI.opLessThanOrEqual(program1)
 
     newProgram1.stack.head must be(OP_TRUE)
@@ -374,7 +401,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
 
     val stack2 = List(ScriptNumber.one, ScriptNumber.zero)
     val script2 = List(OP_LESSTHANOREQUAL)
-    val program2 = ScriptProgram(TestUtil.testProgram, stack2, script2)
+    val program2 =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack2, script2)
     val newProgram2 = AI.opLessThanOrEqual(program2)
 
     newProgram2.stack.head must be(OP_TRUE)
@@ -384,7 +412,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "evaluate an OP_GREATERTHAN correctly" in {
     val stack = List(ScriptNumber.zero, ScriptNumber.one)
     val script = List(OP_GREATERTHAN)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.opGreaterThan(program)
 
     newProgram.stack.head must be(OP_TRUE)
@@ -392,7 +421,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
 
     val stack1 = List(ScriptNumber.zero, ScriptNumber.zero)
     val script1 = List(OP_GREATERTHAN)
-    val program1 = ScriptProgram(TestUtil.testProgram, stack1, script1)
+    val program1 =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack1, script1)
     val newProgram1 = AI.opGreaterThan(program1)
 
     newProgram1.stack.head must be(OP_FALSE)
@@ -400,7 +430,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
 
     val stack2 = List(ScriptNumber.one, ScriptNumber.zero)
     val script2 = List(OP_GREATERTHAN)
-    val program2 = ScriptProgram(TestUtil.testProgram, stack2, script2)
+    val program2 =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack2, script2)
     val newProgram2 = AI.opGreaterThan(program2)
 
     newProgram2.stack.head must be(OP_FALSE)
@@ -410,7 +441,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "evaluate an OP_GREATERTHANOREQUAL correctly" in {
     val stack = List(ScriptNumber.zero, ScriptNumber.one)
     val script = List(OP_GREATERTHANOREQUAL)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.opGreaterThanOrEqual(program)
 
     newProgram.stack.head must be(OP_TRUE)
@@ -418,7 +450,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
 
     val stack1 = List(ScriptNumber.zero, ScriptNumber.zero)
     val script1 = List(OP_GREATERTHANOREQUAL)
-    val program1 = ScriptProgram(TestUtil.testProgram, stack1, script1)
+    val program1 =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack1, script1)
     val newProgram1 = AI.opGreaterThanOrEqual(program1)
 
     newProgram1.stack.head must be(OP_TRUE)
@@ -426,7 +459,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
 
     val stack2 = List(ScriptNumber.one, ScriptNumber.zero)
     val script2 = List(OP_GREATERTHANOREQUAL)
-    val program2 = ScriptProgram(TestUtil.testProgram, stack2, script2)
+    val program2 =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack2, script2)
     val newProgram2 = AI.opGreaterThanOrEqual(program2)
 
     newProgram2.stack.head must be(OP_FALSE)
@@ -538,7 +572,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
     val scriptConstant2 = ScriptConstant("ffffff7f")
     val stack = List(scriptConstant1, scriptConstant2)
     val script = List(OP_ADD)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.opAdd(program)
     newProgram.stack must be(List(ScriptNumber.zero))
     newProgram.script.isEmpty must be(true)
@@ -547,7 +582,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "fail to evaluate all OP codes if the script stack is empty" in {
     val stack = List(ScriptNumber.zero)
     val script = List()
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     Try(AI.opAdd(program)).isFailure must be(true)
     Try(AI.op1Add(program)).isFailure must be(true)
     Try(AI.op1Sub(program)).isFailure must be(true)

--- a/core-test/src/test/scala/org/bitcoins/core/script/bitwise/BitwiseInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/bitwise/BitwiseInterpreterTest.scala
@@ -16,7 +16,8 @@ class BitwiseInterpreterTest extends FlatSpec with MustMatchers {
   "BitwiseInterpreter" must "evaluate OP_EQUAL" in {
     val stack = List(pubKeyHash, pubKeyHash)
     val script = List(OP_EQUAL)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = BI.opEqual(program)
     newProgram.stack.head must be(OP_TRUE)
   }
@@ -24,20 +25,23 @@ class BitwiseInterpreterTest extends FlatSpec with MustMatchers {
   it must "evaluate OP_1 and OP_TRUE to equal" in {
     val stack = List(OP_1, OP_TRUE)
     val script = List(OP_EQUAL)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = BI.opEqual(program)
     newProgram.stack.head must be(OP_TRUE)
   }
 
   it must "throw an exception for OP_EQUAL when we don't have enough items on the stack" in {
     intercept[IllegalArgumentException] {
-      BI.opEqual(ScriptProgram(TestUtil.testProgram, List(), List()))
+      BI.opEqual(
+        ScriptProgram(TestUtil.testProgramExecutionInProgress, List(), List()))
     }
   }
 
   it must "throw an exception for OP_EQUAL when we don't have enough items on the script stack" in {
     intercept[IllegalArgumentException] {
-      BI.opEqual(ScriptProgram(TestUtil.testProgram, List(), List()))
+      BI.opEqual(
+        ScriptProgram(TestUtil.testProgramExecutionInProgress, List(), List()))
     }
   }
 
@@ -64,19 +68,22 @@ class BitwiseInterpreterTest extends FlatSpec with MustMatchers {
   it must "evaluate a ScriptNumber & ScriptConstant to true if they are the same" in {
     val stack = List(ScriptNumber(2), ScriptConstant("02"))
     val script = List(OP_EQUAL)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     BI.opEqual(program).stack.head must be(OP_TRUE)
 
     val stack1 = List(ScriptConstant("02"), ScriptNumber(2))
     val script1 = List(OP_EQUAL)
-    val program1 = ScriptProgram(TestUtil.testProgram, stack1, script1)
+    val program1 =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack1, script1)
     BI.opEqual(program1).stack.head must be(OP_TRUE)
   }
 
   it must "evaluate an OP_0 and ScriptNumberImpl(0) to equal" in {
     val stack = List(OP_0, ScriptNumber.zero)
     val script = List(OP_EQUAL)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     BI.opEqual(program).stack.head must be(OP_TRUE)
   }
 

--- a/core-test/src/test/scala/org/bitcoins/core/script/constant/ConstantInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/constant/ConstantInterpreterTest.scala
@@ -68,7 +68,8 @@ class ConstantInterpreterTest extends FlatSpec with MustMatchers {
   it must "push a constant 2 bytes onto the stack" in {
     val stack = List()
     val script = List(BytesToPushOntoStack(2), ScriptNumber.one, OP_0)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = CI.pushScriptNumberBytesToStack(program)
     newProgram.script.isEmpty must be(true)
     newProgram.stack must be(List(ScriptConstant("0100")))
@@ -78,8 +79,9 @@ class ConstantInterpreterTest extends FlatSpec with MustMatchers {
     val stack = List()
     val script = List(OP_PUSHDATA1, BytesToPushOntoStack(0))
     val program =
-      ScriptProgram(ScriptProgram(TestUtil.testProgram, stack, script),
-                    Seq[ScriptFlag]())
+      ScriptProgram(
+        ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script),
+        Seq[ScriptFlag]())
     val newProgram = CI.opPushData1(program)
     newProgram.stackTopIsFalse must be(true)
     newProgram.stack must be(List(ScriptNumber.zero))
@@ -87,16 +89,18 @@ class ConstantInterpreterTest extends FlatSpec with MustMatchers {
     val stack1 = List()
     val script1 = List(OP_PUSHDATA2, BytesToPushOntoStack(0))
     val program1 =
-      ScriptProgram(ScriptProgram(TestUtil.testProgram, stack1, script1),
-                    Seq[ScriptFlag]())
+      ScriptProgram(
+        ScriptProgram(TestUtil.testProgramExecutionInProgress, stack1, script1),
+        Seq[ScriptFlag]())
     val newProgram1 = CI.opPushData2(program1)
     newProgram1.stack must be(List(ScriptNumber.zero))
 
     val stack2 = List()
     val script2 = List(OP_PUSHDATA4, BytesToPushOntoStack(0))
     val program2 =
-      ScriptProgram(ScriptProgram(TestUtil.testProgram, stack2, script2),
-                    Seq[ScriptFlag]())
+      ScriptProgram(
+        ScriptProgram(TestUtil.testProgramExecutionInProgress, stack2, script2),
+        Seq[ScriptFlag]())
     val newProgram2 = CI.opPushData4(program2)
     newProgram2.stack must be(List(ScriptNumber.zero))
   }
@@ -117,20 +121,23 @@ class ConstantInterpreterTest extends FlatSpec with MustMatchers {
     val stack1 = List()
     val script1 = List(OP_PUSHDATA1, BytesToPushOntoStack(0))
     val program1 =
-      ScriptProgram(ScriptProgram(TestUtil.testProgram, stack1, script1),
-                    Seq[ScriptFlag]())
+      ScriptProgram(
+        ScriptProgram(TestUtil.testProgramExecutionInProgress, stack1, script1),
+        Seq[ScriptFlag]())
 
     val stack2 = List()
     val script2 = List(OP_PUSHDATA2, BytesToPushOntoStack(0))
     val program2 =
-      ScriptProgram(ScriptProgram(TestUtil.testProgram, stack2, script2),
-                    Seq[ScriptFlag]())
+      ScriptProgram(
+        ScriptProgram(TestUtil.testProgramExecutionInProgress, stack2, script2),
+        Seq[ScriptFlag]())
 
     val stack4 = List()
     val script4 = List(OP_PUSHDATA4, BytesToPushOntoStack(0))
     val program4 =
-      ScriptProgram(ScriptProgram(TestUtil.testProgram, stack4, script4),
-                    Seq[ScriptFlag]())
+      ScriptProgram(
+        ScriptProgram(TestUtil.testProgramExecutionInProgress, stack4, script4),
+        Seq[ScriptFlag]())
 
     //purposely call incorrect functions to mismatch opCodes
     intercept[IllegalArgumentException] {
@@ -150,7 +157,8 @@ class ConstantInterpreterTest extends FlatSpec with MustMatchers {
     "BytesToPushOntoStack, ScriptNumber, or ScriptConstant" in {
     val stack = List()
     val script = List(OP_CHECKMULTISIGVERIFY, ScriptNumber.one, OP_0)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
 
     intercept[IllegalArgumentException] {
       CI.pushScriptNumberBytesToStack(program)
@@ -161,8 +169,9 @@ class ConstantInterpreterTest extends FlatSpec with MustMatchers {
     val stack = List()
     val script = List(OP_PUSHDATA4, ScriptNumber.zero)
     val program =
-      ScriptProgram(ScriptProgram(TestUtil.testProgram, stack, script),
-                    Seq[ScriptFlag](ScriptVerifyMinimalData))
+      ScriptProgram(
+        ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script),
+        Seq[ScriptFlag](ScriptVerifyMinimalData))
     val newProgram =
       ScriptProgramTestUtil.toExecutedScriptProgram(CI.opPushData4(program))
     newProgram.error must be(Some(ScriptErrorMinimalData))
@@ -174,7 +183,8 @@ class ConstantInterpreterTest extends FlatSpec with MustMatchers {
         "ffffffff00ffffffff014a7afa8f7d52fd9e17a914b167f19394cd656c34f843ac2387e602007fd15b8700000000")
     val stack = Nil
     val script = List(OP_PUSHDATA1, OP_3, constant)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = CI.opPushData1(program)
     newProgram.stack must be(Seq(constant))
 

--- a/core-test/src/test/scala/org/bitcoins/core/script/crypto/CryptoInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/crypto/CryptoInterpreterTest.scala
@@ -30,7 +30,8 @@ class CryptoInterpreterTest extends FlatSpec with MustMatchers {
   "CryptoInterpreter" must "evaluate OP_HASH160 correctly when it is on top of the script stack" in {
 
     val script = List(OP_HASH160)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = CI.opHash160(program)
 
     newProgram.stack.head must be(
@@ -51,7 +52,8 @@ class CryptoInterpreterTest extends FlatSpec with MustMatchers {
 
   it must "fail to evaluate all OP codes when the script stack is empty" in {
     val script = List()
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     Try(CI.opHash160(program)).isFailure must be(true)
     Try(CI.opRipeMd160(program)).isFailure must be(true)
     Try(CI.opSha256(program)).isFailure must be(true)
@@ -67,7 +69,8 @@ class CryptoInterpreterTest extends FlatSpec with MustMatchers {
   it must "evaluate an OP_RIPEMD160 correctly" in {
     val stack = List(ScriptConstant(""))
     val script = List(OP_RIPEMD160)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = CI.opRipeMd160(program)
     newProgram.stack must be(
       List(ScriptConstant("9c1185a5c5e9fc54612808977ee8f548b2258d31")))
@@ -77,7 +80,8 @@ class CryptoInterpreterTest extends FlatSpec with MustMatchers {
   it must "evaluate a OP_SHA1 correctly" in {
     val stack = List(ScriptConstant("ab"))
     val script = List(OP_SHA1)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = CI.opSha1(program)
     newProgram.stack.head must be(
       ScriptConstant("fe83f217d464f6fdfa5b2b1f87fe3a1a47371196"))
@@ -87,7 +91,8 @@ class CryptoInterpreterTest extends FlatSpec with MustMatchers {
   it must "evaluate an OP_SHA256 correctly" in {
     val stack = List(ScriptConstant(""))
     val script = List(OP_SHA256)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = CI.opSha256(program)
     newProgram.stack must be(
       List(ScriptConstant(
@@ -98,7 +103,8 @@ class CryptoInterpreterTest extends FlatSpec with MustMatchers {
   it must "evaluate an OP_HASH256 correctly" in {
     val stack = List(ScriptConstant(""))
     val script = List(OP_HASH256)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = CI.opHash256(program)
     newProgram.stack must be(
       List(ScriptConstant(
@@ -109,7 +115,8 @@ class CryptoInterpreterTest extends FlatSpec with MustMatchers {
   it must "evaluate an OP_CHECKMULTISIG with zero signatures and zero pubkeys" in {
     val stack = List(OP_0, OP_0, OP_0)
     val script = List(OP_CHECKMULTISIG)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val programNoFlags = ScriptProgram(program, ScriptFlagFactory.empty)
     val newProgram = CI.opCheckMultiSig(programNoFlags)
     newProgram.stack must be(List(OP_TRUE))
@@ -119,7 +126,8 @@ class CryptoInterpreterTest extends FlatSpec with MustMatchers {
   it must "evaluate an OP_CHECKMULTISIG and leave the remaining operations on the stack" in {
     val stack = List(OP_0, OP_0, OP_0, OP_16, OP_16, OP_16)
     val script = List(OP_CHECKMULTISIG, OP_16, OP_16, OP_16, OP_16)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val programNoFlags = ScriptProgram(program, ScriptFlagFactory.empty)
     val newProgram = CI.opCheckMultiSig(programNoFlags)
     newProgram.stack must be(List(OP_TRUE, OP_16, OP_16, OP_16))
@@ -154,7 +162,8 @@ class CryptoInterpreterTest extends FlatSpec with MustMatchers {
     //0 0 0 1 CHECKMULTISIG VERIFY DEPTH 0 EQUAL
     val stack = List(OP_1, OP_0, OP_0, OP_0)
     val script = List(OP_CHECKMULTISIG)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val programNoFlags = ScriptProgram(program, ScriptFlagFactory.empty)
     val newProgram = CI.opCheckMultiSig(programNoFlags)
     newProgram.stack must be(List(OP_TRUE))

--- a/core-test/src/test/scala/org/bitcoins/core/script/locktime/LockTimeInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/locktime/LockTimeInterpreterTest.scala
@@ -146,7 +146,8 @@ class LockTimeInterpreterTest extends FlatSpec with MustMatchers {
                                              txAdjustedSequenceNumber.outputs,
                                              UInt32.zero)
     val t = buildTxSigComponent(adjustedLockTimeTx)
-    val baseProgram = PreExecutionScriptProgram(t)
+    val basePreProgram = PreExecutionScriptProgram(t)
+    val baseProgram = ScriptProgram.toExecutionInProgress(basePreProgram)
     val program = ScriptProgram(baseProgram, stack, script)
     val newProgram = LTI.opCheckLockTimeVerify(program)
     //if an error is hit, the newProgram will be an instance of ExecutedScriptProgram
@@ -175,7 +176,8 @@ class LockTimeInterpreterTest extends FlatSpec with MustMatchers {
                                              txAdjustedSequenceNumber.outputs,
                                              UInt32.zero)
     val t = buildTxSigComponent(adjustedLockTimeTx)
-    val baseProgram = PreExecutionScriptProgram(t)
+    val basePreProgram = PreExecutionScriptProgram(t)
+    val baseProgram = ScriptProgram.toExecutionInProgress(basePreProgram)
     val program = ScriptProgram(baseProgram, stack, script)
     val newProgram = LTI.opCheckLockTimeVerify(program)
     //if an error is hit, the newProgram will be an instance of ExecutedScriptProgram
@@ -202,7 +204,8 @@ class LockTimeInterpreterTest extends FlatSpec with MustMatchers {
                                              txAdjustedSequenceNumber.outputs,
                                              UInt32(500000000))
     val t = buildTxSigComponent(adjustedLockTimeTx)
-    val baseProgram = PreExecutionScriptProgram(t)
+    val basePreProgram = PreExecutionScriptProgram(t)
+    val baseProgram = ScriptProgram.toExecutionInProgress(basePreProgram)
     val program = ScriptProgram(baseProgram, stack, script)
     val newProgram = LTI.opCheckLockTimeVerify(program)
     //if an error is hit, the newProgram will be an instance of ExecutedScriptProgram

--- a/core-test/src/test/scala/org/bitcoins/core/script/splice/SpliceInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/splice/SpliceInterpreterTest.scala
@@ -15,7 +15,8 @@ class SpliceInterpreterTest extends FlatSpec with MustMatchers {
   "SpliceInterpreter" must "evaluate an OP_SIZE on OP_0 correctly" in {
     val stack = List(OP_0)
     val script = List(OP_SIZE)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = SI.opSize(program)
     newProgram.stack must be(List(OP_0, OP_0))
     newProgram.script.isEmpty must be(true)
@@ -25,7 +26,8 @@ class SpliceInterpreterTest extends FlatSpec with MustMatchers {
   it must "deterine the size of script number 0 correctly" in {
     val stack = List(ScriptNumber.zero)
     val script = List(OP_SIZE)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = SI.opSize(program)
     newProgram.stack must be(List(ScriptNumber.zero, ScriptNumber.zero))
     newProgram.script.isEmpty must be(true)
@@ -34,7 +36,8 @@ class SpliceInterpreterTest extends FlatSpec with MustMatchers {
   it must "evaluate an OP_SIZE correctly with 0x7f" in {
     val stack = List(ScriptConstant("7f"))
     val script = List(OP_SIZE)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = SI.opSize(program)
     newProgram.stack must be(List(ScriptNumber(1), ScriptConstant("7f")))
     newProgram.script.isEmpty must be(true)
@@ -44,7 +47,8 @@ class SpliceInterpreterTest extends FlatSpec with MustMatchers {
     //0x8000 == 128 in bitcoin
     val stack = List(ScriptNumber(128))
     val script = List(OP_SIZE)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = SI.opSize(program)
     newProgram.stack must be(List(ScriptNumber(2), ScriptNumber(128)))
     newProgram.script.isEmpty must be(true)
@@ -53,7 +57,8 @@ class SpliceInterpreterTest extends FlatSpec with MustMatchers {
   it must "evaluate an OP_SIZE correctly with a negative number" in {
     val stack = List(ScriptNumber(-1))
     val script = List(OP_SIZE)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = SI.opSize(program)
     newProgram.stack must be(List(ScriptNumber.one, ScriptNumber(-1)))
     newProgram.script.isEmpty must be(true)

--- a/core-test/src/test/scala/org/bitcoins/core/script/stack/StackInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/stack/StackInterpreterTest.scala
@@ -17,7 +17,8 @@ class StackInterpreterTest extends FlatSpec with MustMatchers {
   "StackInterpreter" must "duplicate elements on top of the stack" in {
 
     val script = List(OP_DUP)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = SI.opDup(program)
 
     newProgram.stack.head must be(element1)
@@ -28,7 +29,8 @@ class StackInterpreterTest extends FlatSpec with MustMatchers {
   it must "throw an exception when calling opDup without an OP_DUP on top of the script stack" in {
     intercept[IllegalArgumentException] {
       val script = List()
-      val program = ScriptProgram(TestUtil.testProgram, stack, script)
+      val program =
+        ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
       SI.opDup(program)
     }
   }
@@ -46,7 +48,8 @@ class StackInterpreterTest extends FlatSpec with MustMatchers {
 
   it must "evaluate the OP_DEPTH operator correctly" in {
     val script = List(OP_DEPTH)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = SI.opDepth(program)
 
     newProgram.stack.head.hex must be(BitcoinSUtil.encodeHex(stack.size.toByte))
@@ -55,7 +58,8 @@ class StackInterpreterTest extends FlatSpec with MustMatchers {
   it must "evaluate OP_DEPTH operator correctly when there are zero items on the stack" in {
     val stack = List()
     val script = List(OP_DEPTH)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = SI.opDepth(program)
     newProgram.stack.head must be(ScriptNumber.zero)
   }
@@ -63,7 +67,8 @@ class StackInterpreterTest extends FlatSpec with MustMatchers {
   it must "evaluate an OP_TOALTSTACK operator correctly" in {
     val stack = List(OP_0)
     val script = List(OP_TOALTSTACK)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = SI.opToAltStack(program)
 
     newProgram.stack.isEmpty must be(true)
@@ -75,7 +80,8 @@ class StackInterpreterTest extends FlatSpec with MustMatchers {
   it must "evaluate an OP_DROP operator correctly" in {
     val stack = List(OP_0)
     val script = List(OP_DROP)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = SI.opDrop(program)
 
     newProgram.stack.isEmpty must be(true)
@@ -96,14 +102,16 @@ class StackInterpreterTest extends FlatSpec with MustMatchers {
   it must "evaluate an OP_IFDUP correctly" in {
     val stack = List(ScriptNumber.zero)
     val script = List(OP_IFDUP)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = SI.opIfDup(program)
 
     newProgram.stack must be(stack)
     newProgram.script.isEmpty must be(true)
 
     val stack1 = List(OP_1)
-    val program1 = ScriptProgram(TestUtil.testProgram, stack1, script)
+    val program1 =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack1, script)
     val newProgram1 = SI.opIfDup(program1)
     newProgram1.stack must be(List(OP_1, OP_1))
     newProgram1.script.isEmpty must be(true)
@@ -114,7 +122,8 @@ class StackInterpreterTest extends FlatSpec with MustMatchers {
     val stack = List(OP_0, OP_1)
     val script = List(OP_NIP)
 
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
 
     val newProgram = SI.opNip(program)
 
@@ -148,7 +157,8 @@ class StackInterpreterTest extends FlatSpec with MustMatchers {
   it must "evaluate an OP_OVER correctly" in {
     val stack = List(OP_0, OP_1)
     val script = List(OP_OVER)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = SI.opOver(program)
     newProgram.stack must be(List(OP_1, OP_0, OP_1))
     newProgram.script.isEmpty must be(true)
@@ -184,7 +194,8 @@ class StackInterpreterTest extends FlatSpec with MustMatchers {
                      ScriptConstant("15"),
                      ScriptConstant("16"))
     val script = List(OP_PICK)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = SI.opPick(program)
 
     newProgram.stack must be(
@@ -250,7 +261,8 @@ class StackInterpreterTest extends FlatSpec with MustMatchers {
     val stack =
       List(ScriptConstant("14"), ScriptConstant("15"), ScriptConstant("16"))
     val script = List(OP_ROT)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = SI.opRot(program)
 
     newProgram.stack must be(
@@ -277,7 +289,8 @@ class StackInterpreterTest extends FlatSpec with MustMatchers {
                      ScriptConstant("18"),
                      ScriptConstant("19"))
     val script = List(OP_2ROT)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = SI.op2Rot(program)
 
     newProgram.stack must be(
@@ -313,7 +326,8 @@ class StackInterpreterTest extends FlatSpec with MustMatchers {
                      ScriptConstant("18"),
                      ScriptConstant("19"))
     val script = List(OP_2DROP)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = SI.op2Drop(program)
 
     newProgram.stack must be(
@@ -342,7 +356,8 @@ class StackInterpreterTest extends FlatSpec with MustMatchers {
                      ScriptConstant("18"),
                      ScriptConstant("19"))
     val script = List(OP_SWAP)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = SI.opSwap(program)
     newProgram.stack must be(
       List(ScriptConstant("15"),
@@ -373,7 +388,8 @@ class StackInterpreterTest extends FlatSpec with MustMatchers {
                      ScriptConstant("18"),
                      ScriptConstant("19"))
     val script = List(OP_TUCK)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = SI.opTuck(program)
     newProgram.stack must be(
       List(ScriptConstant("14"),
@@ -406,7 +422,8 @@ class StackInterpreterTest extends FlatSpec with MustMatchers {
                      ScriptConstant("18"),
                      ScriptConstant("19"))
     val script = List(OP_2DUP)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = SI.op2Dup(program)
     newProgram.stack must be(
       List(
@@ -442,7 +459,8 @@ class StackInterpreterTest extends FlatSpec with MustMatchers {
                      ScriptConstant("18"),
                      ScriptConstant("19"))
     val script = List(OP_3DUP)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = SI.op3Dup(program)
 
     newProgram.stack must be(
@@ -479,7 +497,8 @@ class StackInterpreterTest extends FlatSpec with MustMatchers {
                      ScriptConstant("18"),
                      ScriptConstant("19"))
     val script = List(OP_2OVER)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = SI.op2Over(program)
 
     newProgram.stack must be(
@@ -516,7 +535,8 @@ class StackInterpreterTest extends FlatSpec with MustMatchers {
                      ScriptConstant("18"),
                      ScriptConstant("19"))
     val script = List(OP_2SWAP)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = SI.op2Swap(program)
 
     newProgram.stack must be(

--- a/core/src/main/scala/org/bitcoins/core/p2p/NetworkMessage.scala
+++ b/core/src/main/scala/org/bitcoins/core/p2p/NetworkMessage.scala
@@ -10,6 +10,8 @@ import scodec.bits.ByteVector
   * Represents a P2P network message
   */
 sealed abstract class NetworkMessage extends NetworkElement {
+  require(header.payloadSize.toInt == payload.bytes.length, s"Payload size is not what header says it is, " +
+    s"header.payloadSize=${header.payloadSize.toInt} actual=${payload.bytes.length}")
   def header: NetworkHeader
   def payload: NetworkPayload
   override def bytes: ByteVector = RawNetworkMessageSerializer.write(this)

--- a/core/src/main/scala/org/bitcoins/core/p2p/NetworkMessage.scala
+++ b/core/src/main/scala/org/bitcoins/core/p2p/NetworkMessage.scala
@@ -10,8 +10,11 @@ import scodec.bits.ByteVector
   * Represents a P2P network message
   */
 sealed abstract class NetworkMessage extends NetworkElement {
-  require(header.payloadSize.toInt == payload.bytes.length, s"Payload size is not what header says it is, " +
-    s"header.payloadSize=${header.payloadSize.toInt} actual=${payload.bytes.length}")
+  require(
+    header.payloadSize.toInt == payload.bytes.length,
+    s"Payload size is not what header says it is, " +
+      s"header.payloadSize=${header.payloadSize.toInt} actual=${payload.bytes.length}"
+  )
   def header: NetworkHeader
   def payload: NetworkPayload
   override def bytes: ByteVector = RawNetworkMessageSerializer.write(this)

--- a/core/src/main/scala/org/bitcoins/core/p2p/NetworkPayload.scala
+++ b/core/src/main/scala/org/bitcoins/core/p2p/NetworkPayload.scala
@@ -277,6 +277,15 @@ case class HeadersMessage(count: CompactSizeUInt, headers: Vector[BlockHeader])
   override def commandName = NetworkPayload.headersCommandName
 
   override def bytes: ByteVector = RawHeadersMessageSerializer.write(this)
+
+  override def toString(): String = {
+    if (headers.nonEmpty) {
+      s"HeadersMessage(${count},${headers.head.hashBE.hex}..${headers.last.hashBE.hex}"
+    } else {
+      super.toString
+    }
+
+  }
 }
 
 object HeadersMessage extends Factory[HeadersMessage] {
@@ -721,7 +730,7 @@ object PingMessage extends Factory[PingMessage] {
   private case class PingMessageImpl(nonce: UInt64) extends PingMessage
   override def fromBytes(bytes: ByteVector): PingMessage = {
     val pingMsg = RawPingMessageSerializer.read(bytes)
-    PingMessageImpl(pingMsg.nonce)
+    pingMsg
   }
 
   def apply(nonce: UInt64): PingMessage = PingMessageImpl(nonce)
@@ -753,7 +762,7 @@ object PongMessage extends Factory[PongMessage] {
 
   def fromBytes(bytes: ByteVector): PongMessage = {
     val pongMsg = RawPongMessageSerializer.read(bytes)
-    PongMessageImpl(pongMsg.nonce)
+    pongMsg
   }
 
   def apply(nonce: UInt64): PongMessage = PongMessageImpl(nonce)

--- a/core/src/main/scala/org/bitcoins/core/script/ScriptProgram.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/ScriptProgram.scala
@@ -157,27 +157,28 @@ object ScriptProgram extends BitcoinSLogger {
                             Some(error))
   }
 
-  def apply(oldProgram: ScriptProgram, flags: Seq[ScriptFlag]): ScriptProgram =
-    oldProgram match {
-      case program: PreExecutionScriptProgram =>
-        PreExecutionScriptProgram(program.txSignatureComponent,
-                                  program.stack,
-                                  program.script,
-                                  program.originalScript,
-                                  program.altStack,
-                                  flags)
-      case program: ExecutionInProgressScriptProgram =>
-        ExecutionInProgressScriptProgram(program.txSignatureComponent,
-                                         program.stack,
-                                         program.script,
-                                         program.originalScript,
-                                         program.altStack,
-                                         flags,
-                                         program.lastCodeSeparator)
-      case _: ExecutedScriptProgram =>
-        throw new RuntimeException(
-          "Cannot update the script flags on a program that has been executed")
-    }
+  def apply(
+      oldProgram: PreExecutionScriptProgram,
+      flags: Seq[ScriptFlag]): PreExecutionScriptProgram = {
+    PreExecutionScriptProgram(oldProgram.txSignatureComponent,
+                              oldProgram.stack,
+                              oldProgram.script,
+                              oldProgram.originalScript,
+                              oldProgram.altStack,
+                              flags)
+  }
+
+  def apply(
+      oldProgram: ExecutionInProgressScriptProgram,
+      flags: Seq[ScriptFlag]): ExecutionInProgressScriptProgram = {
+    ExecutionInProgressScriptProgram(oldProgram.txSignatureComponent,
+                                     oldProgram.stack,
+                                     oldProgram.script,
+                                     oldProgram.originalScript,
+                                     oldProgram.altStack,
+                                     flags,
+                                     oldProgram.lastCodeSeparator)
+  }
 
   def apply(
       oldProgram: PreExecutionScriptProgram,

--- a/core/src/main/scala/org/bitcoins/core/script/ScriptProgram.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/ScriptProgram.scala
@@ -77,6 +77,9 @@ object PreExecutionScriptProgram {
   }
 }
 
+/** This represents any ScriptProgram that is not PreExecution */
+sealed trait StartedScriptProgram extends ScriptProgram
+
 /**
   * Type for a [[org.bitcoins.core.script.ScriptProgram ScriptProgram]] that is currently being
   * evaluated by the [[org.bitcoins.core.script.interpreter.ScriptInterpreter ScriptInterpreter]].
@@ -91,7 +94,7 @@ case class ExecutionInProgressScriptProgram(
     altStack: List[ScriptToken],
     flags: Seq[ScriptFlag],
     lastCodeSeparator: Option[Int])
-    extends ScriptProgram
+    extends StartedScriptProgram
 
 /**
   * Type for a [[org.bitcoins.core.script.ScriptProgram ScriptProgram]] that has been
@@ -109,7 +112,7 @@ case class ExecutedScriptProgram(
     altStack: List[ScriptToken],
     flags: Seq[ScriptFlag],
     error: Option[ScriptError])
-    extends ScriptProgram
+    extends StartedScriptProgram
 
 /**
   * Factory companion object for [[org.bitcoins.core.script.ScriptProgram ScriptProgram]]
@@ -177,103 +180,102 @@ object ScriptProgram extends BitcoinSLogger {
     }
 
   def apply(
-      oldProgram: ScriptProgram,
+      oldProgram: PreExecutionScriptProgram,
       tokens: Seq[ScriptToken],
-      indicator: UpdateIndicator): ScriptProgram = {
+      indicator: UpdateIndicator): PreExecutionScriptProgram = {
     indicator match {
       case Stack =>
-        oldProgram match {
-          case program: PreExecutionScriptProgram =>
-            PreExecutionScriptProgram(program.txSignatureComponent,
-                                      tokens.toList,
-                                      program.script,
-                                      program.originalScript,
-                                      program.altStack,
-                                      program.flags)
-          case program: ExecutionInProgressScriptProgram =>
-            ExecutionInProgressScriptProgram(program.txSignatureComponent,
-                                             tokens.toList,
-                                             program.script,
-                                             program.originalScript,
-                                             program.altStack,
-                                             program.flags,
-                                             program.lastCodeSeparator)
-          case _: ExecutedScriptProgram =>
-            throw new RuntimeException(
-              "Cannot update stack for program that has been fully executed")
-        }
+        PreExecutionScriptProgram(oldProgram.txSignatureComponent,
+                                  tokens.toList,
+                                  oldProgram.script,
+                                  oldProgram.originalScript,
+                                  oldProgram.altStack,
+                                  oldProgram.flags)
       case Script =>
-        oldProgram match {
-          case program: PreExecutionScriptProgram =>
-            PreExecutionScriptProgram(program.txSignatureComponent,
-                                      program.stack,
-                                      tokens.toList,
-                                      program.originalScript,
-                                      program.altStack,
-                                      program.flags)
-          case program: ExecutionInProgressScriptProgram =>
-            ExecutionInProgressScriptProgram(program.txSignatureComponent,
-                                             program.stack,
-                                             tokens.toList,
-                                             program.originalScript,
-                                             program.altStack,
-                                             program.flags,
-                                             program.lastCodeSeparator)
-          case _: ExecutedScriptProgram =>
-            throw new RuntimeException(
-              "Cannot update the script for a program that has been fully executed")
-        }
+        PreExecutionScriptProgram(oldProgram.txSignatureComponent,
+                                  oldProgram.stack,
+                                  tokens.toList,
+                                  oldProgram.originalScript,
+                                  oldProgram.altStack,
+                                  oldProgram.flags)
       case AltStack =>
-        oldProgram match {
-          case program: PreExecutionScriptProgram =>
-            PreExecutionScriptProgram(program.txSignatureComponent,
-                                      program.stack,
-                                      program.script,
-                                      program.originalScript,
-                                      tokens.toList,
-                                      program.flags)
-          case program: ExecutionInProgressScriptProgram =>
-            ExecutionInProgressScriptProgram(program.txSignatureComponent,
-                                             program.stack,
-                                             program.script,
-                                             program.originalScript,
-                                             tokens.toList,
-                                             program.flags,
-                                             program.lastCodeSeparator)
-          case _: ExecutedScriptProgram =>
-            throw new RuntimeException(
-              "Cannot update the alt stack for a program that has been fully executed")
-        }
-
+        PreExecutionScriptProgram(oldProgram.txSignatureComponent,
+                                  oldProgram.stack,
+                                  oldProgram.script,
+                                  oldProgram.originalScript,
+                                  tokens.toList,
+                                  oldProgram.flags)
       case OriginalScript =>
-        oldProgram match {
-          case program: PreExecutionScriptProgram =>
-            PreExecutionScriptProgram(program.txSignatureComponent,
-                                      program.stack,
-                                      program.script,
-                                      tokens.toList,
-                                      program.altStack,
-                                      program.flags)
-          case program: ExecutionInProgressScriptProgram =>
-            ExecutionInProgressScriptProgram(program.txSignatureComponent,
-                                             program.stack,
-                                             program.script,
-                                             tokens.toList,
-                                             program.altStack,
-                                             program.flags,
-                                             program.lastCodeSeparator)
-          case _: ExecutedScriptProgram =>
-            throw new RuntimeException(
-              "Cannot update the original script for a program that has been fully executed")
-        }
-
+        PreExecutionScriptProgram(oldProgram.txSignatureComponent,
+                                  oldProgram.stack,
+                                  oldProgram.script,
+                                  tokens.toList,
+                                  oldProgram.altStack,
+                                  oldProgram.flags)
     }
   }
 
   def apply(
-      oldProgram: ScriptProgram,
+      oldProgram: ExecutionInProgressScriptProgram,
+      tokens: Seq[ScriptToken],
+      indicator: UpdateIndicator): ExecutionInProgressScriptProgram = {
+    indicator match {
+      case Stack =>
+        ExecutionInProgressScriptProgram(
+          oldProgram.txSignatureComponent,
+          tokens.toList,
+          oldProgram.script,
+          oldProgram.originalScript,
+          oldProgram.altStack,
+          oldProgram.flags,
+          oldProgram.lastCodeSeparator
+        )
+      case Script =>
+        ExecutionInProgressScriptProgram(
+          oldProgram.txSignatureComponent,
+          oldProgram.stack,
+          tokens.toList,
+          oldProgram.originalScript,
+          oldProgram.altStack,
+          oldProgram.flags,
+          oldProgram.lastCodeSeparator
+        )
+      case AltStack =>
+        ExecutionInProgressScriptProgram(
+          oldProgram.txSignatureComponent,
+          oldProgram.stack,
+          oldProgram.script,
+          oldProgram.originalScript,
+          tokens.toList,
+          oldProgram.flags,
+          oldProgram.lastCodeSeparator
+        )
+      case OriginalScript =>
+        ExecutionInProgressScriptProgram(oldProgram.txSignatureComponent,
+                                         oldProgram.stack,
+                                         oldProgram.script,
+                                         tokens.toList,
+                                         oldProgram.altStack,
+                                         oldProgram.flags,
+                                         oldProgram.lastCodeSeparator)
+    }
+  }
+
+  def apply(
+      oldProgram: PreExecutionScriptProgram,
       stackTokens: Seq[ScriptToken],
-      scriptTokens: Seq[ScriptToken]): ScriptProgram = {
+      scriptTokens: Seq[ScriptToken]): PreExecutionScriptProgram = {
+    val updatedStack = ScriptProgram(oldProgram, stackTokens, Stack)
+    val updatedScript = ScriptProgram(updatedStack, scriptTokens, Script)
+    require(updatedStack.stack == stackTokens)
+    require(updatedScript.script == scriptTokens)
+    updatedScript
+  }
+
+  def apply(
+      oldProgram: ExecutionInProgressScriptProgram,
+      stackTokens: Seq[ScriptToken],
+      scriptTokens: Seq[ScriptToken]): ExecutionInProgressScriptProgram = {
     val updatedStack = ScriptProgram(oldProgram, stackTokens, Stack)
     val updatedScript = ScriptProgram(updatedStack, scriptTokens, Script)
     require(updatedStack.stack == stackTokens)
@@ -305,13 +307,7 @@ object ScriptProgram extends BitcoinSLogger {
       indicator: UpdateIndicator,
       lastCodeSeparator: Int): ExecutionInProgressScriptProgram = {
     val updatedIndicator = ScriptProgram(oldProgram, tokens, indicator)
-    updatedIndicator match {
-      case e: ExecutionInProgressScriptProgram =>
-        ScriptProgram(e, lastCodeSeparator)
-      case _: PreExecutionScriptProgram | _: ExecutedScriptProgram =>
-        throw new RuntimeException(
-          "We must have a ExecutionInProgressScriptProgram to update the last OP_CODESEPARATOR index")
-    }
+    ScriptProgram(updatedIndicator, lastCodeSeparator)
   }
 
   /** Updates the [[org.bitcoins.core.script.ScriptProgram.Stack Stack]],
@@ -319,10 +315,27 @@ object ScriptProgram extends BitcoinSLogger {
     * [[org.bitcoins.core.script.ScriptProgram.AltStack AltStack]] of the given
     * [[org.bitcoins.core.script.ScriptProgram ScriptProgram]]. */
   def apply(
-      oldProgram: ScriptProgram,
+      oldProgram: PreExecutionScriptProgram,
       stack: Seq[ScriptToken],
       script: Seq[ScriptToken],
-      altStack: Seq[ScriptToken]): ScriptProgram = {
+      altStack: Seq[ScriptToken]): PreExecutionScriptProgram = {
+    val updatedProgramStack = ScriptProgram(oldProgram, stack, Stack)
+    val updatedProgramScript =
+      ScriptProgram(updatedProgramStack, script, Script)
+    val updatedProgramAltStack =
+      ScriptProgram(updatedProgramScript, altStack, AltStack)
+    updatedProgramAltStack
+  }
+
+  /** Updates the [[org.bitcoins.core.script.ScriptProgram.Stack Stack]],
+    * [[org.bitcoins.core.script.ScriptProgram.Script Script]],
+    * [[org.bitcoins.core.script.ScriptProgram.AltStack AltStack]] of the given
+    * [[org.bitcoins.core.script.ScriptProgram ScriptProgram]]. */
+  def apply(
+      oldProgram: ExecutionInProgressScriptProgram,
+      stack: Seq[ScriptToken],
+      script: Seq[ScriptToken],
+      altStack: Seq[ScriptToken]): ExecutionInProgressScriptProgram = {
     val updatedProgramStack = ScriptProgram(oldProgram, stack, Stack)
     val updatedProgramScript =
       ScriptProgram(updatedProgramStack, script, Script)

--- a/core/src/main/scala/org/bitcoins/core/script/arithmetic/ArithmeticInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/arithmetic/ArithmeticInterpreter.scala
@@ -10,8 +10,8 @@ import org.bitcoins.core.script.result._
 import org.bitcoins.core.script.{
   ExecutedScriptProgram,
   ExecutionInProgressScriptProgram,
-  PreExecutionScriptProgram,
-  ScriptProgram
+  ScriptProgram,
+  StartedScriptProgram
 }
 import org.bitcoins.core.util.{BitcoinSLogger, BitcoinScriptUtil}
 
@@ -24,35 +24,37 @@ sealed abstract class ArithmeticInterpreter {
   private def logger = BitcoinSLogger.logger
 
   /** a is added to b. */
-  def opAdd(program: ScriptProgram): ScriptProgram = {
+  def opAdd(program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_ADD),
             "Script top must be OP_ADD")
     performBinaryArithmeticOperation(program, (x, y) => x + y)
   }
 
   /** Increments the stack top by 1. */
-  def op1Add(program: ScriptProgram): ScriptProgram = {
+  def op1Add(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_1ADD),
             "Script top must be OP_1ADD")
     performUnaryArithmeticOperation(program, x => x + ScriptNumber.one)
   }
 
   /** Decrements the stack top by 1. */
-  def op1Sub(program: ScriptProgram): ScriptProgram = {
+  def op1Sub(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_1SUB),
             "Script top must be OP_1SUB")
     performUnaryArithmeticOperation(program, x => x - ScriptNumber.one)
   }
 
   /** b is subtracted from a. */
-  def opSub(program: ScriptProgram): ScriptProgram = {
+  def opSub(program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_SUB),
             "Script top must be OP_SUB")
     performBinaryArithmeticOperation(program, (x, y) => y - x)
   }
 
   /** Takes the absolute value of the stack top. */
-  def opAbs(program: ScriptProgram): ScriptProgram = {
+  def opAbs(program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_ABS),
             "Script top must be OP_ABS")
     performUnaryArithmeticOperation(
@@ -65,14 +67,15 @@ sealed abstract class ArithmeticInterpreter {
   }
 
   /** Negates the stack top. */
-  def opNegate(program: ScriptProgram): ScriptProgram = {
+  def opNegate(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_NEGATE),
             "Script top must be OP_NEGATE")
     performUnaryArithmeticOperation(program, x => -x)
   }
 
   /** If the input is 0 or 1, it is flipped. Otherwise the output will be 0. */
-  def opNot(program: ScriptProgram): ScriptProgram = {
+  def opNot(program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_NOT),
             "Script top must be OP_NOT")
     performUnaryArithmeticOperation(
@@ -81,7 +84,8 @@ sealed abstract class ArithmeticInterpreter {
   }
 
   /** Returns 0 if the input is 0. 1 otherwise. */
-  def op0NotEqual(program: ScriptProgram): ScriptProgram = {
+  def op0NotEqual(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_0NOTEQUAL),
             "Script top must be OP_0NOTEQUAL")
     performUnaryArithmeticOperation(
@@ -90,7 +94,8 @@ sealed abstract class ArithmeticInterpreter {
   }
 
   /** If both a and b are not 0, the output is 1. Otherwise 0. */
-  def opBoolAnd(program: ScriptProgram): ScriptProgram = {
+  def opBoolAnd(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_BOOLAND),
             "Script top must be OP_BOOLAND")
     performBinaryBooleanOperation(program, (x, y) => {
@@ -101,7 +106,8 @@ sealed abstract class ArithmeticInterpreter {
   }
 
   /** If a or b is not 0, the output is 1. Otherwise 0. */
-  def opBoolOr(program: ScriptProgram): ScriptProgram = {
+  def opBoolOr(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_BOOLOR),
             "Script top must be OP_BOOLOR")
     performBinaryBooleanOperation(program, (x, y) => {
@@ -110,7 +116,8 @@ sealed abstract class ArithmeticInterpreter {
   }
 
   /** Returns 1 if the numbers are equal, 0 otherwise. */
-  def opNumEqual(program: ScriptProgram): ScriptProgram = {
+  def opNumEqual(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_NUMEQUAL),
             "Script top must be OP_NUMEQUAL")
     performBinaryBooleanOperation(program, (x, y) => x.numEqual(y))
@@ -118,7 +125,8 @@ sealed abstract class ArithmeticInterpreter {
 
   /** Same as [[org.bitcoins.core.script.arithmetic.OP_NUMEQUAL OP_NUMEQUAL]], but runs
     * [[org.bitcoins.core.script.control.OP_VERIFY OP_VERIFY]] afterward. */
-  def opNumEqualVerify(program: ScriptProgram): ScriptProgram = {
+  def opNumEqualVerify(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_NUMEQUALVERIFY),
             "Script top must be OP_NUMEQUALVERIFY")
     if (program.stack.size < 2) {
@@ -128,23 +136,24 @@ sealed abstract class ArithmeticInterpreter {
       val numEqualProgram = ScriptProgram(program,
                                           program.stack,
                                           OP_NUMEQUAL :: program.script.tail)
-      val numEqualResult = opNumEqual(numEqualProgram)
-      numEqualResult match {
-        case _: ExecutionInProgressScriptProgram =>
+      val numEqualResultOrError = opNumEqual(numEqualProgram)
+      numEqualResultOrError match {
+        case numEqualResult: ExecutionInProgressScriptProgram =>
           val verifyProgram = ScriptProgram(numEqualResult,
                                             numEqualResult.stack,
                                             OP_VERIFY :: numEqualResult.script)
           val verifyResult =
             ControlOperationsInterpreter.opVerify(verifyProgram)
           verifyResult
-        case _: PreExecutionScriptProgram | _: ExecutedScriptProgram =>
-          numEqualResult
+        case err: ExecutedScriptProgram =>
+          err
       }
     }
   }
 
   /** Returns 1 if the numbers are not equal, 0 otherwise. */
-  def opNumNotEqual(program: ScriptProgram): ScriptProgram = {
+  def opNumNotEqual(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_NUMNOTEQUAL),
             "Script top must be OP_NUMNOTEQUAL")
     performBinaryBooleanOperation(program, (x, y) => {
@@ -153,35 +162,39 @@ sealed abstract class ArithmeticInterpreter {
   }
 
   /** Returns 1 if a is less than b, 0 otherwise. */
-  def opLessThan(program: ScriptProgram): ScriptProgram = {
+  def opLessThan(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_LESSTHAN),
             "Script top must be OP_LESSTHAN")
     performBinaryBooleanOperation(program, (x, y) => y < x)
   }
 
   /** Returns 1 if a is greater than b, 0 otherwise. */
-  def opGreaterThan(program: ScriptProgram): ScriptProgram = {
+  def opGreaterThan(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_GREATERTHAN),
             "Script top must be OP_GREATERTHAN")
     performBinaryBooleanOperation(program, (x, y) => y > x)
   }
 
   /** Returns 1 if a is less than or equal to b, 0 otherwise. */
-  def opLessThanOrEqual(program: ScriptProgram): ScriptProgram = {
+  def opLessThanOrEqual(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_LESSTHANOREQUAL),
             "Script top must be OP_LESSTHANOREQUAL")
     performBinaryBooleanOperation(program, (x, y) => y <= x)
   }
 
   /** Returns 1 if a is greater than or equal to b, 0 otherwise. */
-  def opGreaterThanOrEqual(program: ScriptProgram): ScriptProgram = {
+  def opGreaterThanOrEqual(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_GREATERTHANOREQUAL),
             "Script top must be OP_GREATERTHANOREQUAL")
     performBinaryBooleanOperation(program, (x, y) => y >= x)
   }
 
   /** Returns the smaller of a and b. */
-  def opMin(program: ScriptProgram): ScriptProgram = {
+  def opMin(program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_MIN),
             "Script top must be OP_MIN")
     if (program.stack.size < 2) {
@@ -195,7 +208,7 @@ sealed abstract class ArithmeticInterpreter {
   }
 
   /** Returns the larger of a and b. */
-  def opMax(program: ScriptProgram): ScriptProgram = {
+  def opMax(program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_MAX),
             "Script top must be OP_MAX")
     if (program.stack.size < 2) {
@@ -209,7 +222,8 @@ sealed abstract class ArithmeticInterpreter {
   }
 
   /** Returns 1 if x is within the specified range (left-inclusive), 0 otherwise. */
-  def opWithin(program: ScriptProgram): ScriptProgram = {
+  def opWithin(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_WITHIN),
             "Script top must be OP_WITHIN")
     if (program.stack.size < 3) {
@@ -260,8 +274,8 @@ sealed abstract class ArithmeticInterpreter {
     */
   @tailrec
   private def performUnaryArithmeticOperation(
-      program: ScriptProgram,
-      op: ScriptNumber => ScriptNumber): ScriptProgram = {
+      program: ExecutionInProgressScriptProgram,
+      op: ScriptNumber => ScriptNumber): StartedScriptProgram = {
     program.stack.headOption match {
       case None =>
         logger.error(
@@ -316,8 +330,8 @@ sealed abstract class ArithmeticInterpreter {
     */
   @tailrec
   private def performBinaryArithmeticOperation(
-      program: ScriptProgram,
-      op: (ScriptNumber, ScriptNumber) => ScriptNumber): ScriptProgram = {
+      program: ExecutionInProgressScriptProgram,
+      op: (ScriptNumber, ScriptNumber) => ScriptNumber): StartedScriptProgram = {
     if (program.stack.size < 2) {
       logger.error(
         "We must have two elements to perform a binary arithmetic operation")
@@ -384,8 +398,8 @@ sealed abstract class ArithmeticInterpreter {
     * @return the program with either OP_FALSE or OP_TRUE on the stack top
     */
   private def performBinaryBooleanOperation(
-      program: ScriptProgram,
-      op: (ScriptNumber, ScriptNumber) => Boolean): ScriptProgram = {
+      program: ExecutionInProgressScriptProgram,
+      op: (ScriptNumber, ScriptNumber) => Boolean): StartedScriptProgram = {
     if (program.stack.size < 2) {
       logger.error("We need two stack elements for a binary boolean operation")
       ScriptProgram(program, ScriptErrorInvalidStackOperation)
@@ -420,8 +434,8 @@ sealed abstract class ArithmeticInterpreter {
     * @return the program with the result of op pushed onto the top of the stack
     */
   private def performComparisonOnTwoStackTopItems(
-      program: ScriptProgram,
-      op: (ScriptNumber, ScriptNumber) => ScriptNumber): ScriptProgram = {
+      program: ExecutionInProgressScriptProgram,
+      op: (ScriptNumber, ScriptNumber) => ScriptNumber): StartedScriptProgram = {
     performBinaryArithmeticOperation(program, op)
   }
 

--- a/core/src/main/scala/org/bitcoins/core/script/constant/ConstantInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/constant/ConstantInterpreter.scala
@@ -1,6 +1,10 @@
 package org.bitcoins.core.script.constant
 
-import org.bitcoins.core.script.ScriptProgram
+import org.bitcoins.core.script.{
+  ExecutionInProgressScriptProgram,
+  ScriptProgram,
+  StartedScriptProgram
+}
 import org.bitcoins.core.script.flag.ScriptFlagUtil
 import org.bitcoins.core.script.result._
 import org.bitcoins.core.util.{BitcoinSLogger, BitcoinSUtil, BitcoinScriptUtil}
@@ -14,28 +18,32 @@ sealed abstract class ConstantInterpreter {
   private def logger = BitcoinSLogger.logger
 
   /** The next byte contains the number of bytes to be pushed onto the stack. */
-  def opPushData1(program: ScriptProgram): ScriptProgram = {
+  def opPushData1(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_PUSHDATA1),
             "Top of script stack must be OP_PUSHDATA1")
     opPushData(program)
   }
 
   /** The next two bytes contain the number of bytes to be pushed onto the stack. */
-  def opPushData2(program: ScriptProgram): ScriptProgram = {
+  def opPushData2(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_PUSHDATA2),
             "Top of script stack must be OP_PUSHDATA2")
     opPushData(program)
   }
 
   /** The next four bytes contain the number of bytes to be pushed onto the stack. */
-  def opPushData4(program: ScriptProgram): ScriptProgram = {
+  def opPushData4(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_PUSHDATA4),
             "Top of script stack must be OP_PUSHDATA4")
     opPushData(program)
   }
 
   /** Pushes the number of bytes onto the stack that is specified by script number on the script stack. */
-  def pushScriptNumberBytesToStack(program: ScriptProgram): ScriptProgram = {
+  def pushScriptNumberBytesToStack(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     val bytesNeeded: Long = program.script.head match {
       case OP_PUSHDATA1 | OP_PUSHDATA2 | OP_PUSHDATA4 =>
         bytesNeededForPushOp(program.script(1))
@@ -108,7 +116,8 @@ sealed abstract class ConstantInterpreter {
     * Checks if the MINIMALDATA script flag is set, if so checks if we are using the minimal push operation
     * if we are, then we push the bytes onto the stack.
     */
-  private def opPushData(program: ScriptProgram): ScriptProgram = {
+  private def opPushData(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     //for the case when we have the minimal data flag and the bytes to push onto stack is represented by the
     //constant telling OP_PUSHDATA how many bytes need to go onto the stack
     //for instance OP_PUSHDATA1 OP_0

--- a/core/src/main/scala/org/bitcoins/core/script/crypto/CryptoInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/crypto/CryptoInterpreter.scala
@@ -13,8 +13,6 @@ import org.bitcoins.core.script.{ScriptProgram, _}
 import org.bitcoins.core.util.{BitcoinSLogger, BitcoinScriptUtil, CryptoUtil}
 import scodec.bits.ByteVector
 
-import scala.annotation.tailrec
-
 /**
   * Created by chris on 1/6/16.
   */
@@ -23,35 +21,40 @@ sealed abstract class CryptoInterpreter {
   private def logger = BitcoinSLogger.logger
 
   /** The input is hashed twice: first with SHA-256 and then with RIPEMD-160. */
-  def opHash160(program: ScriptProgram): ScriptProgram = {
+  def opHash160(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_HASH160),
             "Script operation must be OP_HASH160")
     executeHashFunction(program, CryptoUtil.sha256Hash160(_: ByteVector))
   }
 
   /** The input is hashed using RIPEMD-160. */
-  def opRipeMd160(program: ScriptProgram): ScriptProgram = {
+  def opRipeMd160(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_RIPEMD160),
             "Script operation must be OP_RIPEMD160")
     executeHashFunction(program, CryptoUtil.ripeMd160(_: ByteVector))
   }
 
   /** The input is hashed using SHA-256. */
-  def opSha256(program: ScriptProgram): ScriptProgram = {
+  def opSha256(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_SHA256),
             "Script operation must be OP_SHA256")
     executeHashFunction(program, CryptoUtil.sha256(_: ByteVector))
   }
 
   /** The input is hashed two times with SHA-256. */
-  def opHash256(program: ScriptProgram): ScriptProgram = {
+  def opHash256(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_HASH256),
             "Script operation must be OP_HASH256")
     executeHashFunction(program, CryptoUtil.doubleSHA256(_: ByteVector))
   }
 
   /** The input is hashed using SHA-1. */
-  def opSha1(program: ScriptProgram): ScriptProgram = {
+  def opSha1(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_SHA1),
             "Script top must be OP_SHA1")
     executeHashFunction(program, CryptoUtil.sha1(_: ByteVector))
@@ -65,47 +68,38 @@ sealed abstract class CryptoInterpreter {
     * must be a valid signature for this hash and public key.
     * [[https://github.com/bitcoin/bitcoin/blob/528472111b4965b1a99c4bcf08ac5ec93d87f10f/src/script/interpreter.cpp#L880]]
     */
-  def opCheckSig(program: ScriptProgram): ScriptProgram = {
+  def opCheckSig(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_CHECKSIG),
             "Script top must be OP_CHECKSIG")
-    program match {
-      case preExecutionScriptProgram: PreExecutionScriptProgram =>
-        opCheckSig(
-          ScriptProgram.toExecutionInProgress(preExecutionScriptProgram))
-      case executedScriptprogram: ExecutedScriptProgram =>
-        executedScriptprogram
-      case executionInProgressScriptProgram: ExecutionInProgressScriptProgram =>
-        if (executionInProgressScriptProgram.stack.size < 2) {
-          logger.error("OP_CHECKSIG requires at lest two stack elements")
-          ScriptProgram(program, ScriptErrorInvalidStackOperation)
-        } else {
-          val pubKey = ECPublicKey(
-            executionInProgressScriptProgram.stack.head.bytes)
-          val signature = ECDigitalSignature(
-            executionInProgressScriptProgram.stack.tail.head.bytes)
-          val flags = executionInProgressScriptProgram.flags
-          val restOfStack = executionInProgressScriptProgram.stack.tail.tail
-          logger.debug(
-            "Program before removing OP_CODESEPARATOR: " + program.originalScript)
-          val removedOpCodeSeparatorsScript =
-            BitcoinScriptUtil.removeOpCodeSeparator(
-              executionInProgressScriptProgram)
-          logger.debug(
-            "Program after removing OP_CODESEPARATOR: " + removedOpCodeSeparatorsScript)
-          val result = TransactionSignatureChecker.checkSignature(
-            executionInProgressScriptProgram.txSignatureComponent,
-            removedOpCodeSeparatorsScript,
-            pubKey,
-            signature,
-            flags)
-          handleSignatureValidation(program, result, restOfStack)
-        }
+    if (program.stack.size < 2) {
+      logger.error("OP_CHECKSIG requires at lest two stack elements")
+      ScriptProgram(program, ScriptErrorInvalidStackOperation)
+    } else {
+      val pubKey = ECPublicKey(program.stack.head.bytes)
+      val signature = ECDigitalSignature(program.stack.tail.head.bytes)
+      val flags = program.flags
+      val restOfStack = program.stack.tail.tail
+      logger.debug(
+        "Program before removing OP_CODESEPARATOR: " + program.originalScript)
+      val removedOpCodeSeparatorsScript =
+        BitcoinScriptUtil.removeOpCodeSeparator(program)
+      logger.debug(
+        "Program after removing OP_CODESEPARATOR: " + removedOpCodeSeparatorsScript)
+      val result = TransactionSignatureChecker.checkSignature(
+        program.txSignatureComponent,
+        removedOpCodeSeparatorsScript,
+        pubKey,
+        signature,
+        flags)
+      handleSignatureValidation(program, result, restOfStack)
     }
   }
 
   /** Runs [[org.bitcoins.core.script.crypto.OP_CHECKSIG OP_CHECKSIG]] with an
     * [[org.bitcoins.core.script.control.OP_VERIFY OP_VERIFY]] afterwards. */
-  def opCheckSigVerify(program: ScriptProgram): ScriptProgram = {
+  def opCheckSigVerify(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_CHECKSIGVERIFY),
             "Script top must be OP_CHECKSIGVERIFY")
     if (program.stack.size < 2) {
@@ -118,10 +112,10 @@ sealed abstract class CryptoInterpreter {
       logger.debug(
         "Stack after OP_CHECKSIG execution: " + programFromOpCheckSig.stack)
       programFromOpCheckSig match {
-        case _: PreExecutionScriptProgram | _: ExecutedScriptProgram =>
+        case _: ExecutedScriptProgram =>
           programFromOpCheckSig
-        case _: ExecutionInProgressScriptProgram =>
-          ControlOperationsInterpreter.opVerify(programFromOpCheckSig)
+        case p: ExecutionInProgressScriptProgram =>
+          ControlOperationsInterpreter.opVerify(p)
       }
     }
   }
@@ -131,22 +125,16 @@ sealed abstract class CryptoInterpreter {
     * after the most recently-executed
     * [[org.bitcoins.core.script.crypto.OP_CODESEPARATOR OP_CODESEPARATOR]].
     */
-  def opCodeSeparator(program: ScriptProgram): ScriptProgram = {
+  def opCodeSeparator(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_CODESEPARATOR),
             "Script top must be OP_CODESEPARATOR")
-    val e = program match {
-      case e: PreExecutionScriptProgram =>
-        opCodeSeparator(ScriptProgram.toExecutionInProgress(e))
-      case e: ExecutionInProgressScriptProgram =>
-        val indexOfOpCodeSeparator = program.originalScript.size - program.script.size
-        ScriptProgram(e,
-                      program.script.tail,
-                      ScriptProgram.Script,
-                      indexOfOpCodeSeparator)
-      case e: ExecutedScriptProgram =>
-        ScriptProgram(e, ScriptErrorUnknownError)
-    }
-    e
+
+    val indexOfOpCodeSeparator = program.originalScript.size - program.script.size
+    ScriptProgram(program,
+                  program.script.tail,
+                  ScriptProgram.Script,
+                  indexOfOpCodeSeparator)
   }
 
   /**
@@ -160,130 +148,114 @@ sealed abstract class CryptoInterpreter {
     * were placed in the scriptPubKey or redeemScript. If all signatures are valid, 1 is returned, 0 otherwise.
     * Due to a bug, one extra unused value is removed from the stack.
     */
-  @tailrec
-  final def opCheckMultiSig(program: ScriptProgram): ScriptProgram = {
+  final def opCheckMultiSig(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_CHECKMULTISIG),
             "Script top must be OP_CHECKMULTISIG")
     val flags = program.flags
-    program match {
-      case preExecutionScriptProgram: PreExecutionScriptProgram =>
-        opCheckMultiSig(
-          ScriptProgram.toExecutionInProgress(preExecutionScriptProgram))
-      case executedScriptProgram: ExecutedScriptProgram =>
-        executedScriptProgram
-      case executionInProgressScriptProgram: ExecutionInProgressScriptProgram =>
-        if (program.stack.size < 1) {
-          logger.error("OP_CHECKMULTISIG requires at least 1 stack elements")
-          ScriptProgram(executionInProgressScriptProgram,
-                        ScriptErrorInvalidStackOperation)
-        } else {
-          //these next lines remove the appropriate stack/script values after the signatures have been checked
-          val nPossibleSignatures: ScriptNumber =
-            BitcoinScriptUtil.numPossibleSignaturesOnStack(program)
-          if (nPossibleSignatures < ScriptNumber.zero) {
-            logger.error(
-              "We cannot have the number of pubkeys in the script be negative")
-            ScriptProgram(program, ScriptErrorPubKeyCount)
-          } else if (ScriptFlagUtil.requireMinimalData(flags) && !nPossibleSignatures.isShortestEncoding) {
-            logger.error(
-              "The required signatures and the possible signatures must be encoded as the shortest number possible")
-            ScriptProgram(executionInProgressScriptProgram,
-                          ScriptErrorUnknownError)
-          } else if (program.stack.size < 2) {
-            logger.error("We need at least 2 operations on the stack")
-            ScriptProgram(executionInProgressScriptProgram,
-                          ScriptErrorInvalidStackOperation)
-          } else {
-            val mRequiredSignatures: ScriptNumber =
-              BitcoinScriptUtil.numRequiredSignaturesOnStack(program)
 
-            if (ScriptFlagUtil.requireMinimalData(flags) && !mRequiredSignatures.isShortestEncoding) {
-              logger.error(
-                "The required signatures val must be the shortest encoding as possible")
-              return ScriptProgram(executionInProgressScriptProgram,
-                                   ScriptErrorUnknownError)
-            }
+    if (program.stack.size < 1) {
+      logger.error("OP_CHECKMULTISIG requires at least 1 stack elements")
+      ScriptProgram(program, ScriptErrorInvalidStackOperation)
+    } else {
+      //these next lines remove the appropriate stack/script values after the signatures have been checked
+      val nPossibleSignatures: ScriptNumber =
+        BitcoinScriptUtil.numPossibleSignaturesOnStack(program)
+      if (nPossibleSignatures < ScriptNumber.zero) {
+        logger.error(
+          "We cannot have the number of pubkeys in the script be negative")
+        ScriptProgram(program, ScriptErrorPubKeyCount)
+      } else if (ScriptFlagUtil.requireMinimalData(flags) && !nPossibleSignatures.isShortestEncoding) {
+        logger.error(
+          "The required signatures and the possible signatures must be encoded as the shortest number possible")
+        ScriptProgram(program, ScriptErrorUnknownError)
+      } else if (program.stack.size < 2) {
+        logger.error("We need at least 2 operations on the stack")
+        ScriptProgram(program, ScriptErrorInvalidStackOperation)
+      } else {
+        val mRequiredSignatures: ScriptNumber =
+          BitcoinScriptUtil.numRequiredSignaturesOnStack(program)
 
-            if (mRequiredSignatures < ScriptNumber.zero) {
-              logger.error(
-                "We cannot have the number of signatures specified in the script be negative")
-              return ScriptProgram(executionInProgressScriptProgram,
-                                   ScriptErrorSigCount)
-            }
-            logger.debug("nPossibleSignatures: " + nPossibleSignatures)
-            val (pubKeysScriptTokens, stackWithoutPubKeys) =
-              (program.stack.tail.slice(0, nPossibleSignatures.toInt),
-               program.stack.tail
-                 .slice(nPossibleSignatures.toInt, program.stack.tail.size))
-
-            val pubKeys = pubKeysScriptTokens.map(key => ECPublicKey(key.bytes))
-            logger.debug("Public keys on the stack: " + pubKeys)
-            logger.debug("Stack without pubkeys: " + stackWithoutPubKeys)
-            logger.debug("mRequiredSignatures: " + mRequiredSignatures)
-
-            //+1 is for the fact that we have the # of sigs + the script token indicating the # of sigs
-            val signaturesScriptTokens = program.stack.tail.slice(
-              nPossibleSignatures.toInt + 1,
-              nPossibleSignatures.toInt + mRequiredSignatures.toInt + 1)
-            val signatures = signaturesScriptTokens.map(token =>
-              ECDigitalSignature(token.bytes))
-            logger.debug("Signatures on the stack: " + signatures)
-
-            //this contains the extra Script OP that is required for OP_CHECKMULTISIG
-            val stackWithoutPubKeysAndSignatures = stackWithoutPubKeys.tail
-              .slice(mRequiredSignatures.toInt, stackWithoutPubKeys.tail.size)
-            logger.debug(
-              "stackWithoutPubKeysAndSignatures: " + stackWithoutPubKeysAndSignatures)
-            if (pubKeys.size > Consensus.maxPublicKeysPerMultiSig) {
-              logger.error(
-                "We have more public keys than the maximum amount of public keys allowed")
-              ScriptProgram(executionInProgressScriptProgram,
-                            ScriptErrorPubKeyCount)
-            } else if (signatures.size > pubKeys.size) {
-              logger.error(
-                "We have more signatures than public keys inside OP_CHECKMULTISIG")
-              ScriptProgram(executionInProgressScriptProgram,
-                            ScriptErrorSigCount)
-            } else if (stackWithoutPubKeysAndSignatures.size < 1) {
-              logger.error(
-                "OP_CHECKMULTISIG must have a remaining element on the stack afterk execution")
-              //this is because of a bug in bitcoin core for the implementation of OP_CHECKMULTISIG
-              //https://github.com/bitcoin/bitcoin/blob/master/src/script/interpreter.cpp#L966
-              ScriptProgram(executionInProgressScriptProgram,
-                            ScriptErrorInvalidStackOperation)
-            } else if (ScriptFlagUtil.requireNullDummy(flags) &&
-                       (stackWithoutPubKeysAndSignatures.nonEmpty && stackWithoutPubKeysAndSignatures.head.bytes.nonEmpty)) {
-              logger.error(
-                "Script flag null dummy was set however the first element in the script signature was not an OP_0, stackWithoutPubKeysAndSignatures: " + stackWithoutPubKeysAndSignatures)
-              ScriptProgram(executionInProgressScriptProgram,
-                            ScriptErrorSigNullDummy)
-            } else {
-              //remove the last OP_CODESEPARATOR
-              val removedOpCodeSeparatorsScript =
-                BitcoinScriptUtil.removeOpCodeSeparator(
-                  executionInProgressScriptProgram)
-              val isValidSignatures: TransactionSignatureCheckerResult =
-                TransactionSignatureChecker.multiSignatureEvaluator(
-                  executionInProgressScriptProgram.txSignatureComponent,
-                  removedOpCodeSeparatorsScript,
-                  signatures,
-                  pubKeys,
-                  flags,
-                  mRequiredSignatures.toLong)
-
-              //remove the extra OP_0 (null dummy) for OP_CHECKMULTISIG from the stack
-              val restOfStack = stackWithoutPubKeysAndSignatures.tail
-              handleSignatureValidation(program, isValidSignatures, restOfStack)
-            }
-          }
+        if (ScriptFlagUtil.requireMinimalData(flags) && !mRequiredSignatures.isShortestEncoding) {
+          logger.error(
+            "The required signatures val must be the shortest encoding as possible")
+          return ScriptProgram(program, ScriptErrorUnknownError)
         }
+
+        if (mRequiredSignatures < ScriptNumber.zero) {
+          logger.error(
+            "We cannot have the number of signatures specified in the script be negative")
+          return ScriptProgram(program, ScriptErrorSigCount)
+        }
+        logger.debug("nPossibleSignatures: " + nPossibleSignatures)
+        val (pubKeysScriptTokens, stackWithoutPubKeys) =
+          (program.stack.tail.slice(0, nPossibleSignatures.toInt),
+           program.stack.tail
+             .slice(nPossibleSignatures.toInt, program.stack.tail.size))
+
+        val pubKeys = pubKeysScriptTokens.map(key => ECPublicKey(key.bytes))
+        logger.debug("Public keys on the stack: " + pubKeys)
+        logger.debug("Stack without pubkeys: " + stackWithoutPubKeys)
+        logger.debug("mRequiredSignatures: " + mRequiredSignatures)
+
+        //+1 is for the fact that we have the # of sigs + the script token indicating the # of sigs
+        val signaturesScriptTokens = program.stack.tail.slice(
+          nPossibleSignatures.toInt + 1,
+          nPossibleSignatures.toInt + mRequiredSignatures.toInt + 1)
+        val signatures =
+          signaturesScriptTokens.map(token => ECDigitalSignature(token.bytes))
+        logger.debug("Signatures on the stack: " + signatures)
+
+        //this contains the extra Script OP that is required for OP_CHECKMULTISIG
+        val stackWithoutPubKeysAndSignatures = stackWithoutPubKeys.tail
+          .slice(mRequiredSignatures.toInt, stackWithoutPubKeys.tail.size)
+        logger.debug(
+          "stackWithoutPubKeysAndSignatures: " + stackWithoutPubKeysAndSignatures)
+        if (pubKeys.size > Consensus.maxPublicKeysPerMultiSig) {
+          logger.error(
+            "We have more public keys than the maximum amount of public keys allowed")
+          ScriptProgram(program, ScriptErrorPubKeyCount)
+        } else if (signatures.size > pubKeys.size) {
+          logger.error(
+            "We have more signatures than public keys inside OP_CHECKMULTISIG")
+          ScriptProgram(program, ScriptErrorSigCount)
+        } else if (stackWithoutPubKeysAndSignatures.size < 1) {
+          logger.error(
+            "OP_CHECKMULTISIG must have a remaining element on the stack afterk execution")
+          //this is because of a bug in bitcoin core for the implementation of OP_CHECKMULTISIG
+          //https://github.com/bitcoin/bitcoin/blob/master/src/script/interpreter.cpp#L966
+          ScriptProgram(program, ScriptErrorInvalidStackOperation)
+        } else if (ScriptFlagUtil.requireNullDummy(flags) &&
+                   (stackWithoutPubKeysAndSignatures.nonEmpty && stackWithoutPubKeysAndSignatures.head.bytes.nonEmpty)) {
+          logger.error(
+            "Script flag null dummy was set however the first element in the script signature was not an OP_0, stackWithoutPubKeysAndSignatures: " + stackWithoutPubKeysAndSignatures)
+          ScriptProgram(program, ScriptErrorSigNullDummy)
+        } else {
+          //remove the last OP_CODESEPARATOR
+          val removedOpCodeSeparatorsScript =
+            BitcoinScriptUtil.removeOpCodeSeparator(program)
+          val isValidSignatures: TransactionSignatureCheckerResult =
+            TransactionSignatureChecker.multiSignatureEvaluator(
+              program.txSignatureComponent,
+              removedOpCodeSeparatorsScript,
+              signatures,
+              pubKeys,
+              flags,
+              mRequiredSignatures.toLong)
+
+          //remove the extra OP_0 (null dummy) for OP_CHECKMULTISIG from the stack
+          val restOfStack = stackWithoutPubKeysAndSignatures.tail
+          handleSignatureValidation(program, isValidSignatures, restOfStack)
+        }
+      }
     }
   }
 
   /** Runs
     * [[org.bitcoins.core.script.crypto.OP_CHECKMULTISIG OP_CHECKMULTISIG]] with an
     * [[org.bitcoins.core.script.control.OP_VERIFY OP_VERIFY]] afterwards */
-  def opCheckMultiSigVerify(program: ScriptProgram): ScriptProgram = {
+  def opCheckMultiSigVerify(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_CHECKMULTISIGVERIFY),
             "Script top must be OP_CHECKMULTISIGVERIFY")
     if (program.stack.size < 3) {
@@ -297,10 +269,10 @@ sealed abstract class CryptoInterpreter {
       logger.debug(
         "Stack after OP_CHECKMULTSIG execution: " + programFromOpCheckMultiSig.stack)
       programFromOpCheckMultiSig match {
-        case _: PreExecutionScriptProgram | _: ExecutedScriptProgram =>
+        case _: ExecutedScriptProgram =>
           programFromOpCheckMultiSig
-        case _: ExecutionInProgressScriptProgram =>
-          ControlOperationsInterpreter.opVerify(programFromOpCheckMultiSig)
+        case p: ExecutionInProgressScriptProgram =>
+          ControlOperationsInterpreter.opVerify(p)
       }
     }
   }
@@ -314,8 +286,8 @@ sealed abstract class CryptoInterpreter {
     * @return
     */
   private def executeHashFunction(
-      program: ScriptProgram,
-      hashFunction: ByteVector => HashDigest): ScriptProgram = {
+      program: ExecutionInProgressScriptProgram,
+      hashFunction: ByteVector => HashDigest): StartedScriptProgram = {
     if (program.stack.nonEmpty) {
       val stackTop = program.stack.head
       val hash = ScriptConstant(hashFunction(stackTop.bytes).bytes)
@@ -328,9 +300,9 @@ sealed abstract class CryptoInterpreter {
   }
 
   private def handleSignatureValidation(
-      program: ScriptProgram,
+      program: ExecutionInProgressScriptProgram,
       result: TransactionSignatureCheckerResult,
-      restOfStack: Seq[ScriptToken]): ScriptProgram = result match {
+      restOfStack: Seq[ScriptToken]): StartedScriptProgram = result match {
     case SignatureValidationSuccess =>
       //means that all of the signatures were correctly encoded and
       //that all of the signatures were valid signatures for the given

--- a/core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
@@ -30,18 +30,16 @@ import scala.util.{Failure, Success, Try}
 /**
   * Created by chris on 1/6/16.
   */
-sealed abstract class ScriptInterpreter {
-
-  private def logger = BitcoinSLogger.logger
+sealed abstract class ScriptInterpreter extends BitcoinSLogger {
 
   /**
     * Currently bitcoin core limits the maximum number of non-push operations per script
     * to 201
     */
-  private lazy val maxScriptOps = 201
+  private lazy val MAX_SCRIPT_OPS = 201
 
   /** We cannot push an element larger than 520 bytes onto the stack */
-  private lazy val maxPushSize = 520
+  private lazy val MAX_PUSH_SIZE = 520
 
   /**
     * Runs an entire script though our script programming language and
@@ -49,73 +47,110 @@ sealed abstract class ScriptInterpreter {
     * indicating if the script was valid, or if not what error it encountered
     */
   def run(program: PreExecutionScriptProgram): ScriptResult = {
-    val scriptSig = program.txSignatureComponent.scriptSignature
     val scriptPubKey = program.txSignatureComponent.scriptPubKey
     val flags = program.flags
+
     val p2shEnabled = ScriptFlagUtil.p2shEnabled(flags)
     val segwitEnabled = ScriptFlagUtil.segWitEnabled(flags)
-    val executedProgram: ExecutedScriptProgram =
-      if (ScriptFlagUtil.requirePushOnly(flags)
-          && !BitcoinScriptUtil.isPushOnly(program.script)) {
-        logger.error(
-          "We can only have push operations inside of the script sig when the SIGPUSHONLY flag is set")
-        ScriptProgram(program, ScriptErrorSigPushOnly)
-      } else if (scriptSig.isInstanceOf[P2SHScriptSignature] && p2shEnabled &&
-                 !BitcoinScriptUtil.isPushOnly(scriptSig.asm)) {
-        logger.error(
-          "P2SH scriptSigs are required to be push only by definition - see BIP16, got: " + scriptSig.asm)
-        ScriptProgram(program, ScriptErrorSigPushOnly)
-      } else {
-        val scriptSigExecutedProgram = loop(program, 0)
-        logger.trace(s"scriptSigExecutedProgram $scriptSigExecutedProgram")
-        val t = scriptSigExecutedProgram.txSignatureComponent
-        val scriptPubKeyProgram = ExecutionInProgressScriptProgram(
-          t,
-          scriptSigExecutedProgram.stack,
-          t.scriptPubKey.asm.toList,
-          t.scriptPubKey.asm.toList,
-          Nil,
-          scriptSigExecutedProgram.flags,
-          None)
-        val scriptPubKeyExecutedProgram: ExecutedScriptProgram =
-          loop(scriptPubKeyProgram, 0)
-        logger.trace(
-          s"scriptPubKeyExecutedProgram $scriptPubKeyExecutedProgram")
-        if (scriptSigExecutedProgram.error.isDefined) {
-          scriptSigExecutedProgram
-        } else if (scriptPubKeyExecutedProgram.error.isDefined || scriptPubKeyExecutedProgram.stackTopIsFalse) {
-          scriptPubKeyExecutedProgram
-        } else {
-          scriptPubKey match {
-            case witness: WitnessScriptPubKey =>
-              if (segwitEnabled)
-                executeSegWitScript(scriptPubKeyExecutedProgram, witness).get
-              else scriptPubKeyExecutedProgram
-            case _: P2SHScriptPubKey =>
-              if (p2shEnabled) executeP2shScript(scriptSigExecutedProgram)
-              else scriptPubKeyExecutedProgram
-            case _: P2PKHScriptPubKey | _: P2PKScriptPubKey |
-                _: MultiSignatureScriptPubKey | _: CSVScriptPubKey |
-                _: CLTVScriptPubKey | _: NonStandardScriptPubKey |
-                _: WitnessCommitment | EmptyScriptPubKey =>
-              scriptPubKeyExecutedProgram
-          }
-        }
-      }
-    logger.trace("Executed Script Program: " + executedProgram)
-    if (executedProgram.error.isDefined) executedProgram.error.get
-    else if (hasUnexpectedWitness(program)) {
-      //note: the 'program' value we pass above is intentional, we need to check the original program
-      //as the 'executedProgram' may have had the scriptPubKey value changed to the rebuilt ScriptPubKey of the witness program
 
-      ScriptErrorWitnessUnexpected
-    } else if (executedProgram.stackTopIsTrue && flags.contains(
-                 ScriptVerifyCleanStack)) {
-      //require that the stack after execution has exactly one element on it
-      if (executedProgram.stack.size == 1) ScriptOk
-      else ScriptErrorCleanStack
-    } else if (executedProgram.stackTopIsTrue) ScriptOk
-    else ScriptErrorEvalFalse
+    val executedProgram: ExecutedScriptProgram =
+      programFlagsViolated(program) match {
+        case Some(err) => ScriptProgram(program, err)
+        case None =>
+          val scriptSigExecutedProgram = loop(program, 0)
+          logger.trace(s"scriptSigExecutedProgram $scriptSigExecutedProgram")
+
+          val sigComponent = scriptSigExecutedProgram.txSignatureComponent
+          val scriptPubKeyProgram = ExecutionInProgressScriptProgram(
+            txSignatureComponent = sigComponent,
+            stack = scriptSigExecutedProgram.stack,
+            script = sigComponent.scriptPubKey.asm.toList,
+            originalScript = sigComponent.scriptPubKey.asm.toList,
+            altStack = Nil,
+            flags = scriptSigExecutedProgram.flags,
+            lastCodeSeparator = None
+          )
+
+          val scriptPubKeyExecutedProgram: ExecutedScriptProgram =
+            loop(scriptPubKeyProgram, 0)
+          logger.trace(
+            s"scriptPubKeyExecutedProgram $scriptPubKeyExecutedProgram")
+
+          if (scriptSigExecutedProgram.error.isDefined) {
+            scriptSigExecutedProgram
+          } else if (scriptPubKeyExecutedProgram.error.isDefined || scriptPubKeyExecutedProgram.stackTopIsFalse) {
+            scriptPubKeyExecutedProgram
+          } else {
+            scriptPubKey match {
+              case witness: WitnessScriptPubKey =>
+                if (segwitEnabled)
+                  executeSegWitScript(scriptPubKeyExecutedProgram, witness).get
+                else scriptPubKeyExecutedProgram
+              case _: P2SHScriptPubKey =>
+                if (p2shEnabled) executeP2shScript(scriptSigExecutedProgram)
+                else scriptPubKeyExecutedProgram
+              case _: P2PKHScriptPubKey | _: P2PKScriptPubKey |
+                  _: MultiSignatureScriptPubKey | _: CSVScriptPubKey |
+                  _: CLTVScriptPubKey | _: NonStandardScriptPubKey |
+                  _: WitnessCommitment | EmptyScriptPubKey =>
+                scriptPubKeyExecutedProgram
+            }
+          }
+      }
+
+    logger.trace("Executed Script Program: " + executedProgram)
+
+    evaluateExecutedScriptProgram(program, executedProgram)
+  }
+
+  private def programFlagsViolated(
+      program: PreExecutionScriptProgram): Option[ScriptError] = {
+    val scriptSig = program.txSignatureComponent.scriptSignature
+    val flags = program.flags
+    val p2shEnabled = ScriptFlagUtil.p2shEnabled(flags)
+
+    if (ScriptFlagUtil.requirePushOnly(flags)
+        && !BitcoinScriptUtil.isPushOnly(program.script)) {
+      logger.error(
+        "We can only have push operations inside of the script sig when the SIGPUSHONLY flag is set")
+      Some(ScriptErrorSigPushOnly)
+    } else {
+      scriptSig match {
+        case _: P2SHScriptSignature
+            if p2shEnabled && !BitcoinScriptUtil.isPushOnly(scriptSig.asm) =>
+          logger.error(
+            "P2SH scriptSigs are required to be push only by definition - see BIP16, got: " + scriptSig.asm)
+          Some(ScriptErrorSigPushOnly)
+        case _: ScriptSignature => None
+      }
+    }
+  }
+
+  private def evaluateExecutedScriptProgram(
+      program: PreExecutionScriptProgram,
+      executedProgram: ExecutedScriptProgram): ScriptResult = {
+    executedProgram.error match {
+      case Some(err) => err
+      case None =>
+        if (hasUnexpectedWitness(program)) {
+          //note: the 'program' value we pass above is intentional, we need to check the original program
+          //as the 'executedProgram' may have had the scriptPubKey value changed to the rebuilt ScriptPubKey of the witness program
+          ScriptErrorWitnessUnexpected
+        } else if (executedProgram.stackTopIsTrue) {
+          if (program.flags.contains(ScriptVerifyCleanStack)) {
+            //require that the stack after execution has exactly one element on it
+            if (executedProgram.stack.size == 1) {
+              ScriptOk
+            } else {
+              ScriptErrorCleanStack
+            }
+          } else {
+            ScriptOk
+          }
+        } else {
+          ScriptErrorEvalFalse
+        }
+    }
   }
 
   /**
@@ -191,85 +226,84 @@ sealed abstract class ScriptInterpreter {
     } else if (scriptPubKeyExecutedProgram.error.isDefined) {
       scriptPubKeyExecutedProgram
     } else {
-      scriptPubKeyExecutedProgram.stackTopIsTrue match {
-        case true =>
-          logger.debug(
-            "Hashes matched between the p2shScriptSignature & the p2shScriptPubKey")
+      if (scriptPubKeyExecutedProgram.stackTopIsTrue) {
+        logger.debug(
+          "Hashes matched between the p2shScriptSignature & the p2shScriptPubKey")
 
-          //we need to run the deserialized redeemScript & the scriptSignature without the serialized redeemScript
-          val stack = scriptPubKeyExecutedProgram.stack
+        //we need to run the deserialized redeemScript & the scriptSignature without the serialized redeemScript
+        val stack = scriptPubKeyExecutedProgram.stack
 
-          val redeemScriptBytes = stack.head.bytes
+        val redeemScriptBytes = stack.head.bytes
 
-          val c = CompactSizeUInt.calculateCompactSizeUInt(redeemScriptBytes)
+        val c = CompactSizeUInt.calculateCompactSizeUInt(redeemScriptBytes)
 
-          val redeemScript = ScriptPubKey(c.bytes ++ redeemScriptBytes)
+        val redeemScript = ScriptPubKey(c.bytes ++ redeemScriptBytes)
 
-          redeemScript match {
+        redeemScript match {
 
-            case p2wpkh: P2WPKHWitnessSPKV0 =>
-              val wtxSigP2SH = scriptPubKeyExecutedProgram.txSignatureComponent
-                .asInstanceOf[WitnessTxSigComponentP2SH]
+          case p2wpkh: P2WPKHWitnessSPKV0 =>
+            val wtxSigP2SH = scriptPubKeyExecutedProgram.txSignatureComponent
+              .asInstanceOf[WitnessTxSigComponentP2SH]
 
-              //for the p2sh(p2wpkh) case
-              //https://github.com/bitcoin/bitcoin/blob/78dae8caccd82cfbfd76557f1fb7d7557c7b5edb/src/script/interpreter.cpp#L1437
+            //for the p2sh(p2wpkh) case
+            //https://github.com/bitcoin/bitcoin/blob/78dae8caccd82cfbfd76557f1fb7d7557c7b5edb/src/script/interpreter.cpp#L1437
 
-              val pushOp = BitcoinScriptUtil.calculatePushOp(redeemScriptBytes)
+            val pushOp = BitcoinScriptUtil.calculatePushOp(redeemScriptBytes)
 
-              val expectedScriptBytes = BitcoinSUtil.toByteVector(pushOp) ++ redeemScriptBytes
+            val expectedScriptBytes = BitcoinSUtil.toByteVector(pushOp) ++ redeemScriptBytes
 
-              val isExpectedScriptBytes = scriptSig.asmBytes == expectedScriptBytes
-              if (segwitEnabled &&
-                  wtxSigP2SH.witness.stack.size == 2 &&
-                  isExpectedScriptBytes) {
-                executeSegWitScript(scriptPubKeyExecutedProgram, p2wpkh).get
-              } else if (segwitEnabled) {
-                ScriptProgram(oldProgram = scriptPubKeyExecutedProgram,
-                              error = ScriptErrorWitnessMalleatedP2SH)
-              } else {
-                //segwit not enabled, treat as old spk
-                run(scriptPubKeyExecutedProgram, p2wpkh)
-              }
+            val isExpectedScriptBytes = scriptSig.asmBytes == expectedScriptBytes
+            if (segwitEnabled &&
+                wtxSigP2SH.witness.stack.size == 2 &&
+                isExpectedScriptBytes) {
+              executeSegWitScript(scriptPubKeyExecutedProgram, p2wpkh).get
+            } else if (segwitEnabled) {
+              ScriptProgram(oldProgram = scriptPubKeyExecutedProgram,
+                            error = ScriptErrorWitnessMalleatedP2SH)
+            } else {
+              //segwit not enabled, treat as old spk
+              run(scriptPubKeyExecutedProgram, p2wpkh)
+            }
 
-            case p2wsh: P2WSHWitnessSPKV0 =>
-              val pushOp = BitcoinScriptUtil.calculatePushOp(redeemScriptBytes)
+          case p2wsh: P2WSHWitnessSPKV0 =>
+            val pushOp = BitcoinScriptUtil.calculatePushOp(redeemScriptBytes)
 
-              val expectedScriptBytes = BitcoinSUtil.toByteVector(pushOp) ++ redeemScriptBytes
+            val expectedScriptBytes = BitcoinSUtil.toByteVector(pushOp) ++ redeemScriptBytes
 
-              val isExpectedScriptBytes = scriptSig.asmBytes == expectedScriptBytes
+            val isExpectedScriptBytes = scriptSig.asmBytes == expectedScriptBytes
 
-              if (segwitEnabled && isExpectedScriptBytes) {
-                // The scriptSig must be _exactly_ a single push of the redeemScript. Otherwise we
-                // reintroduce malleability.
-                logger.debug(
-                  "redeem script was witness script pubkey, segwit was enabled, scriptSig was single push of redeemScript")
-                //TODO: remove .get here
-                executeSegWitScript(scriptPubKeyExecutedProgram, p2wsh).get
-              } else if (segwitEnabled && (scriptSig.asmBytes != expectedScriptBytes)) {
-                logger.error(
-                  "Segwit was enabled, but p2sh redeem script was malleated")
-                logger.error("ScriptSig bytes: " + scriptSig.hex)
-                logger.error(
-                  "expected scriptsig bytes: " + expectedScriptBytes.toHex)
-                ScriptProgram(scriptPubKeyExecutedProgram,
-                              ScriptErrorWitnessMalleatedP2SH)
-              } else {
-                logger.warn(
-                  "redeem script was witness script pubkey, segwit was NOT enabled")
-                //treat the segwit scriptpubkey as any other redeem script
-                run(scriptPubKeyExecutedProgram, p2wsh)
-              }
-            case s @ (_: P2SHScriptPubKey | _: P2PKHScriptPubKey |
-                _: P2PKScriptPubKey | _: MultiSignatureScriptPubKey |
-                _: CLTVScriptPubKey | _: CSVScriptPubKey |
-                _: NonStandardScriptPubKey | _: WitnessCommitment |
-                _: UnassignedWitnessScriptPubKey | EmptyScriptPubKey) =>
-              run(scriptPubKeyExecutedProgram, s)
-          }
-        case false =>
-          logger.warn(
-            "P2SH scriptPubKey hash did not match the hash for the serialized redeemScript")
-          scriptPubKeyExecutedProgram
+            if (segwitEnabled && isExpectedScriptBytes) {
+              // The scriptSig must be _exactly_ a single push of the redeemScript. Otherwise we
+              // reintroduce malleability.
+              logger.debug(
+                "redeem script was witness script pubkey, segwit was enabled, scriptSig was single push of redeemScript")
+              //TODO: remove .get here
+              executeSegWitScript(scriptPubKeyExecutedProgram, p2wsh).get
+            } else if (segwitEnabled && (scriptSig.asmBytes != expectedScriptBytes)) {
+              logger.error(
+                "Segwit was enabled, but p2sh redeem script was malleated")
+              logger.error("ScriptSig bytes: " + scriptSig.hex)
+              logger.error(
+                "expected scriptsig bytes: " + expectedScriptBytes.toHex)
+              ScriptProgram(scriptPubKeyExecutedProgram,
+                            ScriptErrorWitnessMalleatedP2SH)
+            } else {
+              logger.warn(
+                "redeem script was witness script pubkey, segwit was NOT enabled")
+              //treat the segwit scriptpubkey as any other redeem script
+              run(scriptPubKeyExecutedProgram, p2wsh)
+            }
+          case s @ (_: P2SHScriptPubKey | _: P2PKHScriptPubKey |
+              _: P2PKScriptPubKey | _: MultiSignatureScriptPubKey |
+              _: CLTVScriptPubKey | _: CSVScriptPubKey |
+              _: NonStandardScriptPubKey | _: WitnessCommitment |
+              _: UnassignedWitnessScriptPubKey | EmptyScriptPubKey) =>
+            run(scriptPubKeyExecutedProgram, s)
+        }
+      } else {
+        logger.warn(
+          "P2SH scriptPubKey hash did not match the hash for the serialized redeemScript")
+        scriptPubKeyExecutedProgram
       }
     }
 
@@ -288,22 +322,22 @@ sealed abstract class ScriptInterpreter {
       case b: BaseTxSigComponent =>
         val scriptSig =
           scriptPubKeyExecutedProgram.txSignatureComponent.scriptSignature
-        if (scriptSig != EmptyScriptSignature && !b.scriptPubKey
-              .isInstanceOf[P2SHScriptPubKey]) {
-          Success(
-            ScriptProgram(scriptPubKeyExecutedProgram,
-                          ScriptErrorWitnessMalleated))
-        } else {
-          witnessScriptPubKey.witnessVersion match {
-            case WitnessVersion0 =>
-              logger.error(
-                "Cannot verify witness program with a BaseTxSigComponent")
-              Success(
-                ScriptProgram(scriptPubKeyExecutedProgram,
-                              ScriptErrorWitnessProgramWitnessEmpty))
-            case UnassignedWitness(_) =>
-              evaluateUnassignedWitness(b)
-          }
+        (scriptSig, b.scriptPubKey) match {
+          case (EmptyScriptSignature, _) | (_, _: P2SHScriptPubKey) =>
+            witnessScriptPubKey.witnessVersion match {
+              case WitnessVersion0 =>
+                logger.error(
+                  "Cannot verify witness program with a BaseTxSigComponent")
+                Success(
+                  ScriptProgram(scriptPubKeyExecutedProgram,
+                                ScriptErrorWitnessProgramWitnessEmpty))
+              case UnassignedWitness(_) =>
+                evaluateUnassignedWitness(b)
+            }
+          case (_, _) =>
+            Success(
+              ScriptProgram(scriptPubKeyExecutedProgram,
+                            ScriptErrorWitnessMalleated))
         }
       case w: WitnessTxSigComponent =>
         val scriptSig =
@@ -314,16 +348,18 @@ sealed abstract class ScriptInterpreter {
         val witness = w.witness
         //scriptsig must be empty if we have raw p2wsh
         //if script pubkey is a P2SHScriptPubKey then we have P2SH(P2WSH)
-        if (scriptSig != EmptyScriptSignature && !w.scriptPubKey
-              .isInstanceOf[P2SHScriptPubKey]) {
-          Success(
-            ScriptProgram(scriptPubKeyExecutedProgram,
-                          ScriptErrorWitnessMalleated))
-        } else if (witness.stack.exists(_.size > maxPushSize)) {
-          Success(
-            ScriptProgram(scriptPubKeyExecutedProgram, ScriptErrorPushSize))
-        } else {
-          verifyWitnessProgram(witnessVersion, witness, witnessProgram, w)
+        (scriptSig, w.scriptPubKey) match {
+          case (EmptyScriptSignature, _) | (_, _: P2SHScriptPubKey) =>
+            if (witness.stack.exists(_.size > MAX_PUSH_SIZE)) {
+              Success(
+                ScriptProgram(scriptPubKeyExecutedProgram, ScriptErrorPushSize))
+            } else {
+              verifyWitnessProgram(witnessVersion, witness, witnessProgram, w)
+            }
+          case (_, _) =>
+            Success(
+              ScriptProgram(scriptPubKeyExecutedProgram,
+                            ScriptErrorWitnessMalleated))
         }
       case _: WitnessTxSigComponentRebuilt =>
         Failure(new IllegalArgumentException(
@@ -399,368 +435,384 @@ sealed abstract class ScriptInterpreter {
     logger.trace("Stack: " + program.stack)
     logger.trace("Script: " + program.script)
     val scriptByteVector = BitcoinSUtil.toByteVector(program.script)
-    if (opCount > maxScriptOps && !program
-          .isInstanceOf[ExecutedScriptProgram]) {
-      logger.error(
-        "We have reached the maximum amount of script operations allowed")
-      logger.error(
-        "Here are the remaining operations in the script: " + program.script)
-      loop(ScriptProgram(program, ScriptErrorOpCount), opCount)
-    } else if (scriptByteVector.length > 10000 && !program
-                 .isInstanceOf[ExecutedScriptProgram]) {
-      logger.error("We cannot run a script that is larger than 10,000 bytes")
-      program match {
-        case p: PreExecutionScriptProgram =>
-          loop(ScriptProgram(ScriptProgram.toExecutionInProgress(p),
-                             ScriptErrorScriptSize),
-               opCount)
-        case _: ExecutionInProgressScriptProgram | _: ExecutedScriptProgram =>
-          loop(ScriptProgram(program, ScriptErrorScriptSize), opCount)
-      }
-    } else {
-      program match {
-        case p: PreExecutionScriptProgram =>
-          loop(ScriptProgram.toExecutionInProgress(p, Some(p.stack)), opCount)
-        case p: ExecutedScriptProgram =>
-          val countedOps = program.originalScript
-            .map(BitcoinScriptUtil.countsTowardsScriptOpLimit(_))
-            .count(_ == true)
-          logger.trace("Counted ops: " + countedOps)
-          if (countedOps > maxScriptOps && p.error.isEmpty) {
-            loop(ScriptProgram(p, ScriptErrorOpCount), opCount)
-          } else p
+    program match {
+      case _: PreExecutionScriptProgram | _: ExecutionInProgressScriptProgram
+          if opCount > MAX_SCRIPT_OPS =>
+        logger.error(
+          "We have reached the maximum amount of script operations allowed")
+        logger.error(
+          "Here are the remaining operations in the script: " + program.script)
+        loop(ScriptProgram(program, ScriptErrorOpCount), opCount)
+      case p: PreExecutionScriptProgram if scriptByteVector.length > 10000 =>
+        logger.error("We cannot run a script that is larger than 10,000 bytes")
+        loop(ScriptProgram(ScriptProgram.toExecutionInProgress(p),
+                           ScriptErrorScriptSize),
+             opCount)
+      case _: ExecutionInProgressScriptProgram
+          if scriptByteVector.length > 10000 =>
+        logger.error("We cannot run a script that is larger than 10,000 bytes")
+        loop(ScriptProgram(program, ScriptErrorScriptSize), opCount)
+      case _ =>
+        program match {
+          case p: PreExecutionScriptProgram =>
+            loop(ScriptProgram.toExecutionInProgress(p, Some(p.stack)), opCount)
+          case p: ExecutedScriptProgram =>
+            val countedOps = program.originalScript
+              .count(BitcoinScriptUtil.countsTowardsScriptOpLimit)
+            logger.trace("Counted ops: " + countedOps)
+            if (countedOps > MAX_SCRIPT_OPS && p.error.isEmpty) {
+              loop(ScriptProgram(p, ScriptErrorOpCount), opCount)
+            } else p
 
-        case p: ExecutionInProgressScriptProgram =>
-          p.script match {
-            //if at any time we see that the program is not valid
-            //cease script execution
-            case _ if p.script.intersect(Seq(OP_VERIF, OP_VERNOTIF)).nonEmpty =>
-              logger.error(
-                "Script is invalid even when a OP_VERIF or OP_VERNOTIF occurs in an unexecuted OP_IF branch")
-              loop(ScriptProgram(p, ScriptErrorBadOpCode), opCount)
-            //disabled splice operation
-            case _
-                if p.script
-                  .intersect(Seq(OP_CAT, OP_SUBSTR, OP_LEFT, OP_RIGHT))
-                  .nonEmpty =>
-              logger.error(
-                "Script is invalid because it contains a disabled splice operation")
-              loop(ScriptProgram(p, ScriptErrorDisabledOpCode), opCount)
-            //disabled bitwise operations
-            case _
-                if p.script
-                  .intersect(Seq(OP_INVERT, OP_AND, OP_OR, OP_XOR))
-                  .nonEmpty =>
-              logger.error(
-                "Script is invalid because it contains a disabled bitwise operation")
-              loop(ScriptProgram(p, ScriptErrorDisabledOpCode), opCount)
-            //disabled arithmetic operations
-            case _
-                if p.script
-                  .intersect(
-                    Seq(OP_MUL,
-                        OP_2MUL,
-                        OP_DIV,
-                        OP_2DIV,
-                        OP_MOD,
-                        OP_LSHIFT,
-                        OP_RSHIFT))
-                  .nonEmpty =>
-              logger.error(
-                "Script is invalid because it contains a disabled arithmetic operation")
-              loop(ScriptProgram(p, ScriptErrorDisabledOpCode), opCount)
-            //program cannot contain a push operation > 520 bytes
-            case _
-                if (p.script.exists(token => token.bytes.size > maxPushSize)) =>
-              logger.error(
-                "We have a script constant that is larger than 520 bytes, this is illegal: " + p.script)
-              loop(ScriptProgram(p, ScriptErrorPushSize), opCount)
-            //program stack size cannot be greater than 1000 elements
-            case _ if ((p.stack.size + p.altStack.size) > 1000) =>
-              logger.error(
-                "We cannot have a stack + alt stack size larger than 1000 elements")
-              loop(ScriptProgram(p, ScriptErrorStackSize), opCount)
+          case p: ExecutionInProgressScriptProgram =>
+            p.script match {
+              //if at any time we see that the program is not valid
+              //cease script execution
+              case _
+                  if p.script.intersect(Seq(OP_VERIF, OP_VERNOTIF)).nonEmpty =>
+                logger.error(
+                  "Script is invalid even when a OP_VERIF or OP_VERNOTIF occurs in an unexecuted OP_IF branch")
+                loop(ScriptProgram(p, ScriptErrorBadOpCode), opCount)
+              //disabled splice operation
+              case _
+                  if p.script
+                    .intersect(Seq(OP_CAT, OP_SUBSTR, OP_LEFT, OP_RIGHT))
+                    .nonEmpty =>
+                logger.error(
+                  "Script is invalid because it contains a disabled splice operation")
+                loop(ScriptProgram(p, ScriptErrorDisabledOpCode), opCount)
+              //disabled bitwise operations
+              case _
+                  if p.script
+                    .intersect(Seq(OP_INVERT, OP_AND, OP_OR, OP_XOR))
+                    .nonEmpty =>
+                logger.error(
+                  "Script is invalid because it contains a disabled bitwise operation")
+                loop(ScriptProgram(p, ScriptErrorDisabledOpCode), opCount)
+              //disabled arithmetic operations
+              case _
+                  if p.script
+                    .intersect(
+                      Seq(OP_MUL,
+                          OP_2MUL,
+                          OP_DIV,
+                          OP_2DIV,
+                          OP_MOD,
+                          OP_LSHIFT,
+                          OP_RSHIFT))
+                    .nonEmpty =>
+                logger.error(
+                  "Script is invalid because it contains a disabled arithmetic operation")
+                loop(ScriptProgram(p, ScriptErrorDisabledOpCode), opCount)
+              //program cannot contain a push operation > 520 bytes
+              case _
+                  if p.script.exists(token =>
+                    token.bytes.size > MAX_PUSH_SIZE) =>
+                logger.error(
+                  "We have a script constant that is larger than 520 bytes, this is illegal: " + p.script)
+                loop(ScriptProgram(p, ScriptErrorPushSize), opCount)
+              //program stack size cannot be greater than 1000 elements
+              case _ if (p.stack.size + p.altStack.size) > 1000 =>
+                logger.error(
+                  "We cannot have a stack + alt stack size larger than 1000 elements")
+                loop(ScriptProgram(p, ScriptErrorStackSize), opCount)
 
-            //stack operations
-            case OP_DUP :: _ =>
-              loop(StackInterpreter.opDup(p), calcOpCount(opCount, OP_DUP))
-            case OP_DEPTH :: _ =>
-              loop(StackInterpreter.opDepth(p), calcOpCount(opCount, OP_DEPTH))
-            case OP_TOALTSTACK :: _ =>
-              loop(StackInterpreter.opToAltStack(p),
-                   calcOpCount(opCount, OP_TOALTSTACK))
-            case OP_FROMALTSTACK :: _ =>
-              loop(StackInterpreter.opFromAltStack(p),
-                   calcOpCount(opCount, OP_FROMALTSTACK))
-            case OP_DROP :: _ =>
-              loop(StackInterpreter.opDrop(p), calcOpCount(opCount, OP_DROP))
-            case OP_IFDUP :: _ =>
-              loop(StackInterpreter.opIfDup(p), calcOpCount(opCount, OP_IFDUP))
-            case OP_NIP :: _ =>
-              loop(StackInterpreter.opNip(p), calcOpCount(opCount, OP_NIP))
-            case OP_OVER :: _ =>
-              loop(StackInterpreter.opOver(p), calcOpCount(opCount, OP_OVER))
-            case OP_PICK :: _ =>
-              loop(StackInterpreter.opPick(p), calcOpCount(opCount, OP_PICK))
-            case OP_ROLL :: _ =>
-              loop(StackInterpreter.opRoll(p), calcOpCount(opCount, OP_ROLL))
-            case OP_ROT :: _ =>
-              loop(StackInterpreter.opRot(p), calcOpCount(opCount, OP_ROT))
-            case OP_2ROT :: _ =>
-              loop(StackInterpreter.op2Rot(p), calcOpCount(opCount, OP_2ROT))
-            case OP_2DROP :: _ =>
-              loop(StackInterpreter.op2Drop(p), calcOpCount(opCount, OP_2DROP))
-            case OP_SWAP :: _ =>
-              loop(StackInterpreter.opSwap(p), calcOpCount(opCount, OP_SWAP))
-            case OP_TUCK :: _ =>
-              loop(StackInterpreter.opTuck(p), calcOpCount(opCount, OP_TUCK))
-            case OP_2DUP :: _ =>
-              loop(StackInterpreter.op2Dup(p), calcOpCount(opCount, OP_2DUP))
-            case OP_3DUP :: _ =>
-              loop(StackInterpreter.op3Dup(p), calcOpCount(opCount, OP_3DUP))
-            case OP_2OVER :: _ =>
-              loop(StackInterpreter.op2Over(p), calcOpCount(opCount, OP_2OVER))
-            case OP_2SWAP :: _ =>
-              loop(StackInterpreter.op2Swap(p), calcOpCount(opCount, OP_2SWAP))
+              //stack operations
+              case OP_DUP :: _ =>
+                loop(StackInterpreter.opDup(p), calcOpCount(opCount, OP_DUP))
+              case OP_DEPTH :: _ =>
+                loop(StackInterpreter.opDepth(p),
+                     calcOpCount(opCount, OP_DEPTH))
+              case OP_TOALTSTACK :: _ =>
+                loop(StackInterpreter.opToAltStack(p),
+                     calcOpCount(opCount, OP_TOALTSTACK))
+              case OP_FROMALTSTACK :: _ =>
+                loop(StackInterpreter.opFromAltStack(p),
+                     calcOpCount(opCount, OP_FROMALTSTACK))
+              case OP_DROP :: _ =>
+                loop(StackInterpreter.opDrop(p), calcOpCount(opCount, OP_DROP))
+              case OP_IFDUP :: _ =>
+                loop(StackInterpreter.opIfDup(p),
+                     calcOpCount(opCount, OP_IFDUP))
+              case OP_NIP :: _ =>
+                loop(StackInterpreter.opNip(p), calcOpCount(opCount, OP_NIP))
+              case OP_OVER :: _ =>
+                loop(StackInterpreter.opOver(p), calcOpCount(opCount, OP_OVER))
+              case OP_PICK :: _ =>
+                loop(StackInterpreter.opPick(p), calcOpCount(opCount, OP_PICK))
+              case OP_ROLL :: _ =>
+                loop(StackInterpreter.opRoll(p), calcOpCount(opCount, OP_ROLL))
+              case OP_ROT :: _ =>
+                loop(StackInterpreter.opRot(p), calcOpCount(opCount, OP_ROT))
+              case OP_2ROT :: _ =>
+                loop(StackInterpreter.op2Rot(p), calcOpCount(opCount, OP_2ROT))
+              case OP_2DROP :: _ =>
+                loop(StackInterpreter.op2Drop(p),
+                     calcOpCount(opCount, OP_2DROP))
+              case OP_SWAP :: _ =>
+                loop(StackInterpreter.opSwap(p), calcOpCount(opCount, OP_SWAP))
+              case OP_TUCK :: _ =>
+                loop(StackInterpreter.opTuck(p), calcOpCount(opCount, OP_TUCK))
+              case OP_2DUP :: _ =>
+                loop(StackInterpreter.op2Dup(p), calcOpCount(opCount, OP_2DUP))
+              case OP_3DUP :: _ =>
+                loop(StackInterpreter.op3Dup(p), calcOpCount(opCount, OP_3DUP))
+              case OP_2OVER :: _ =>
+                loop(StackInterpreter.op2Over(p),
+                     calcOpCount(opCount, OP_2OVER))
+              case OP_2SWAP :: _ =>
+                loop(StackInterpreter.op2Swap(p),
+                     calcOpCount(opCount, OP_2SWAP))
 
-            //arithmetic operations
-            case OP_ADD :: _ =>
-              loop(ArithmeticInterpreter.opAdd(p), calcOpCount(opCount, OP_ADD))
-            case OP_1ADD :: _ =>
-              loop(ArithmeticInterpreter.op1Add(p),
-                   calcOpCount(opCount, OP_1ADD))
-            case OP_1SUB :: _ =>
-              loop(ArithmeticInterpreter.op1Sub(p),
-                   calcOpCount(opCount, OP_1SUB))
-            case OP_SUB :: _ =>
-              loop(ArithmeticInterpreter.opSub(p), calcOpCount(opCount, OP_SUB))
-            case OP_ABS :: _ =>
-              loop(ArithmeticInterpreter.opAbs(p), calcOpCount(opCount, OP_ABS))
-            case OP_NEGATE :: _ =>
-              loop(ArithmeticInterpreter.opNegate(p),
-                   calcOpCount(opCount, OP_NEGATE))
-            case OP_NOT :: _ =>
-              loop(ArithmeticInterpreter.opNot(p), calcOpCount(opCount, OP_NOT))
-            case OP_0NOTEQUAL :: _ =>
-              loop(ArithmeticInterpreter.op0NotEqual(p),
-                   calcOpCount(opCount, OP_0NOTEQUAL))
-            case OP_BOOLAND :: _ =>
-              loop(ArithmeticInterpreter.opBoolAnd(p),
-                   calcOpCount(opCount, OP_BOOLAND))
-            case OP_BOOLOR :: _ =>
-              loop(ArithmeticInterpreter.opBoolOr(p),
-                   calcOpCount(opCount, OP_BOOLOR))
-            case OP_NUMEQUAL :: _ =>
-              loop(ArithmeticInterpreter.opNumEqual(p),
-                   calcOpCount(opCount, OP_NUMEQUAL))
-            case OP_NUMEQUALVERIFY :: _ =>
-              loop(ArithmeticInterpreter.opNumEqualVerify(p),
-                   calcOpCount(opCount, OP_NUMEQUALVERIFY))
-            case OP_NUMNOTEQUAL :: _ =>
-              loop(ArithmeticInterpreter.opNumNotEqual(p),
-                   calcOpCount(opCount, OP_NUMNOTEQUAL))
-            case OP_LESSTHAN :: _ =>
-              loop(ArithmeticInterpreter.opLessThan(p),
-                   calcOpCount(opCount, OP_LESSTHAN))
-            case OP_GREATERTHAN :: _ =>
-              loop(ArithmeticInterpreter.opGreaterThan(p),
-                   calcOpCount(opCount, OP_GREATERTHAN))
-            case OP_LESSTHANOREQUAL :: _ =>
-              loop(ArithmeticInterpreter.opLessThanOrEqual(p),
-                   calcOpCount(opCount, OP_LESSTHANOREQUAL))
-            case OP_GREATERTHANOREQUAL :: _ =>
-              loop(ArithmeticInterpreter.opGreaterThanOrEqual(p),
-                   calcOpCount(opCount, OP_GREATERTHANOREQUAL))
-            case OP_MIN :: _ =>
-              loop(ArithmeticInterpreter.opMin(p), calcOpCount(opCount, OP_MIN))
-            case OP_MAX :: _ =>
-              loop(ArithmeticInterpreter.opMax(p), calcOpCount(opCount, OP_MAX))
-            case OP_WITHIN :: _ =>
-              loop(ArithmeticInterpreter.opWithin(p),
-                   calcOpCount(opCount, OP_WITHIN))
+              //arithmetic operations
+              case OP_ADD :: _ =>
+                loop(ArithmeticInterpreter.opAdd(p),
+                     calcOpCount(opCount, OP_ADD))
+              case OP_1ADD :: _ =>
+                loop(ArithmeticInterpreter.op1Add(p),
+                     calcOpCount(opCount, OP_1ADD))
+              case OP_1SUB :: _ =>
+                loop(ArithmeticInterpreter.op1Sub(p),
+                     calcOpCount(opCount, OP_1SUB))
+              case OP_SUB :: _ =>
+                loop(ArithmeticInterpreter.opSub(p),
+                     calcOpCount(opCount, OP_SUB))
+              case OP_ABS :: _ =>
+                loop(ArithmeticInterpreter.opAbs(p),
+                     calcOpCount(opCount, OP_ABS))
+              case OP_NEGATE :: _ =>
+                loop(ArithmeticInterpreter.opNegate(p),
+                     calcOpCount(opCount, OP_NEGATE))
+              case OP_NOT :: _ =>
+                loop(ArithmeticInterpreter.opNot(p),
+                     calcOpCount(opCount, OP_NOT))
+              case OP_0NOTEQUAL :: _ =>
+                loop(ArithmeticInterpreter.op0NotEqual(p),
+                     calcOpCount(opCount, OP_0NOTEQUAL))
+              case OP_BOOLAND :: _ =>
+                loop(ArithmeticInterpreter.opBoolAnd(p),
+                     calcOpCount(opCount, OP_BOOLAND))
+              case OP_BOOLOR :: _ =>
+                loop(ArithmeticInterpreter.opBoolOr(p),
+                     calcOpCount(opCount, OP_BOOLOR))
+              case OP_NUMEQUAL :: _ =>
+                loop(ArithmeticInterpreter.opNumEqual(p),
+                     calcOpCount(opCount, OP_NUMEQUAL))
+              case OP_NUMEQUALVERIFY :: _ =>
+                loop(ArithmeticInterpreter.opNumEqualVerify(p),
+                     calcOpCount(opCount, OP_NUMEQUALVERIFY))
+              case OP_NUMNOTEQUAL :: _ =>
+                loop(ArithmeticInterpreter.opNumNotEqual(p),
+                     calcOpCount(opCount, OP_NUMNOTEQUAL))
+              case OP_LESSTHAN :: _ =>
+                loop(ArithmeticInterpreter.opLessThan(p),
+                     calcOpCount(opCount, OP_LESSTHAN))
+              case OP_GREATERTHAN :: _ =>
+                loop(ArithmeticInterpreter.opGreaterThan(p),
+                     calcOpCount(opCount, OP_GREATERTHAN))
+              case OP_LESSTHANOREQUAL :: _ =>
+                loop(ArithmeticInterpreter.opLessThanOrEqual(p),
+                     calcOpCount(opCount, OP_LESSTHANOREQUAL))
+              case OP_GREATERTHANOREQUAL :: _ =>
+                loop(ArithmeticInterpreter.opGreaterThanOrEqual(p),
+                     calcOpCount(opCount, OP_GREATERTHANOREQUAL))
+              case OP_MIN :: _ =>
+                loop(ArithmeticInterpreter.opMin(p),
+                     calcOpCount(opCount, OP_MIN))
+              case OP_MAX :: _ =>
+                loop(ArithmeticInterpreter.opMax(p),
+                     calcOpCount(opCount, OP_MAX))
+              case OP_WITHIN :: _ =>
+                loop(ArithmeticInterpreter.opWithin(p),
+                     calcOpCount(opCount, OP_WITHIN))
 
-            //bitwise operations
-            case OP_EQUAL :: _ =>
-              loop(BitwiseInterpreter.opEqual(p),
-                   calcOpCount(opCount, OP_EQUAL))
+              //bitwise operations
+              case OP_EQUAL :: _ =>
+                loop(BitwiseInterpreter.opEqual(p),
+                     calcOpCount(opCount, OP_EQUAL))
 
-            case OP_EQUALVERIFY :: _ =>
-              loop(BitwiseInterpreter.opEqualVerify(p),
-                   calcOpCount(opCount, OP_EQUALVERIFY))
+              case OP_EQUALVERIFY :: _ =>
+                loop(BitwiseInterpreter.opEqualVerify(p),
+                     calcOpCount(opCount, OP_EQUALVERIFY))
 
-            case OP_0 :: t =>
-              loop(ScriptProgram(p, ScriptNumber.zero :: p.stack, t),
-                   calcOpCount(opCount, OP_0))
-            case (scriptNumberOp: ScriptNumberOperation) :: t =>
-              loop(ScriptProgram(p,
-                                 ScriptNumber(scriptNumberOp.toLong) :: p.stack,
-                                 t),
-                   calcOpCount(opCount, scriptNumberOp))
-            case (bytesToPushOntoStack: BytesToPushOntoStack) :: _ =>
-              loop(ConstantInterpreter.pushScriptNumberBytesToStack(p),
-                   calcOpCount(opCount, bytesToPushOntoStack))
-            case (scriptNumber: ScriptNumber) :: t =>
-              loop(ScriptProgram(p, scriptNumber :: p.stack, t),
-                   calcOpCount(opCount, scriptNumber))
-            case OP_PUSHDATA1 :: _ =>
-              loop(ConstantInterpreter.opPushData1(p),
-                   calcOpCount(opCount, OP_PUSHDATA1))
-            case OP_PUSHDATA2 :: _ =>
-              loop(ConstantInterpreter.opPushData2(p),
-                   calcOpCount(opCount, OP_PUSHDATA2))
-            case OP_PUSHDATA4 :: _ =>
-              loop(ConstantInterpreter.opPushData4(p),
-                   calcOpCount(opCount, OP_PUSHDATA4))
+              case OP_0 :: t =>
+                loop(ScriptProgram(p, ScriptNumber.zero :: p.stack, t),
+                     calcOpCount(opCount, OP_0))
+              case (scriptNumberOp: ScriptNumberOperation) :: t =>
+                loop(
+                  ScriptProgram(p,
+                                ScriptNumber(scriptNumberOp.toLong) :: p.stack,
+                                t),
+                  calcOpCount(opCount, scriptNumberOp))
+              case (bytesToPushOntoStack: BytesToPushOntoStack) :: _ =>
+                loop(ConstantInterpreter.pushScriptNumberBytesToStack(p),
+                     calcOpCount(opCount, bytesToPushOntoStack))
+              case (scriptNumber: ScriptNumber) :: t =>
+                loop(ScriptProgram(p, scriptNumber :: p.stack, t),
+                     calcOpCount(opCount, scriptNumber))
+              case OP_PUSHDATA1 :: _ =>
+                loop(ConstantInterpreter.opPushData1(p),
+                     calcOpCount(opCount, OP_PUSHDATA1))
+              case OP_PUSHDATA2 :: _ =>
+                loop(ConstantInterpreter.opPushData2(p),
+                     calcOpCount(opCount, OP_PUSHDATA2))
+              case OP_PUSHDATA4 :: _ =>
+                loop(ConstantInterpreter.opPushData4(p),
+                     calcOpCount(opCount, OP_PUSHDATA4))
 
-            case (x: ScriptConstant) :: t =>
-              loop(ScriptProgram(p, x :: p.stack, t), calcOpCount(opCount, x))
+              case (x: ScriptConstant) :: t =>
+                loop(ScriptProgram(p, x :: p.stack, t), calcOpCount(opCount, x))
 
-            //control operations
-            case OP_IF :: _ =>
-              loop(ControlOperationsInterpreter.opIf(p),
-                   calcOpCount(opCount, OP_IF))
-            case OP_NOTIF :: _ =>
-              loop(ControlOperationsInterpreter.opNotIf(p),
-                   calcOpCount(opCount, OP_NOTIF))
-            case OP_ELSE :: _ =>
-              loop(ControlOperationsInterpreter.opElse(p),
-                   calcOpCount(opCount, OP_ELSE))
-            case OP_ENDIF :: _ =>
-              loop(ControlOperationsInterpreter.opEndIf(p),
-                   calcOpCount(opCount, OP_ENDIF))
-            case OP_RETURN :: _ =>
-              loop(ControlOperationsInterpreter.opReturn(p),
-                   calcOpCount(opCount, OP_RETURN))
+              //control operations
+              case OP_IF :: _ =>
+                loop(ControlOperationsInterpreter.opIf(p),
+                     calcOpCount(opCount, OP_IF))
+              case OP_NOTIF :: _ =>
+                loop(ControlOperationsInterpreter.opNotIf(p),
+                     calcOpCount(opCount, OP_NOTIF))
+              case OP_ELSE :: _ =>
+                loop(ControlOperationsInterpreter.opElse(p),
+                     calcOpCount(opCount, OP_ELSE))
+              case OP_ENDIF :: _ =>
+                loop(ControlOperationsInterpreter.opEndIf(p),
+                     calcOpCount(opCount, OP_ENDIF))
+              case OP_RETURN :: _ =>
+                loop(ControlOperationsInterpreter.opReturn(p),
+                     calcOpCount(opCount, OP_RETURN))
 
-            case OP_VERIFY :: _ =>
-              loop(ControlOperationsInterpreter.opVerify(p),
-                   calcOpCount(opCount, OP_VERIFY))
+              case OP_VERIFY :: _ =>
+                loop(ControlOperationsInterpreter.opVerify(p),
+                     calcOpCount(opCount, OP_VERIFY))
 
-            //crypto operations
-            case OP_HASH160 :: _ =>
-              loop(CryptoInterpreter.opHash160(p),
-                   calcOpCount(opCount, OP_HASH160))
-            case OP_CHECKSIG :: _ =>
-              loop(CryptoInterpreter.opCheckSig(p),
-                   calcOpCount(opCount, OP_CHECKSIG))
-            case OP_CHECKSIGVERIFY :: _ =>
-              loop(CryptoInterpreter.opCheckSigVerify(p),
-                   calcOpCount(opCount, OP_CHECKSIGVERIFY))
-            case OP_SHA1 :: _ =>
-              loop(CryptoInterpreter.opSha1(p), calcOpCount(opCount, OP_SHA1))
-            case OP_RIPEMD160 :: _ =>
-              loop(CryptoInterpreter.opRipeMd160(p),
-                   calcOpCount(opCount, OP_RIPEMD160))
-            case OP_SHA256 :: _ =>
-              loop(CryptoInterpreter.opSha256(p),
-                   calcOpCount(opCount, OP_SHA256))
-            case OP_HASH256 :: _ =>
-              loop(CryptoInterpreter.opHash256(p),
-                   calcOpCount(opCount, OP_HASH256))
-            case OP_CODESEPARATOR :: _ =>
-              loop(CryptoInterpreter.opCodeSeparator(p),
-                   calcOpCount(opCount, OP_CODESEPARATOR))
-            case OP_CHECKMULTISIG :: _ =>
-              CryptoInterpreter.opCheckMultiSig(p) match {
-                case newProgram: ExecutedScriptProgram =>
-                  //script was marked invalid for other reasons, don't need to update the opcount
-                  loop(newProgram, opCount)
-                case newProgram @ (_: ExecutionInProgressScriptProgram |
-                    _: PreExecutionScriptProgram) =>
-                  val newOpCount = calcOpCount(opCount, OP_CHECKMULTISIG) + BitcoinScriptUtil
-                    .numPossibleSignaturesOnStack(program)
-                    .toInt
-                  loop(newProgram, newOpCount)
-              }
-            case OP_CHECKMULTISIGVERIFY :: _ =>
-              CryptoInterpreter.opCheckMultiSigVerify(p) match {
-                case newProgram: ExecutedScriptProgram =>
-                  //script was marked invalid for other reasons, don't need to update the opcount
-                  loop(newProgram, opCount)
-                case newProgram @ (_: ExecutionInProgressScriptProgram |
-                    _: PreExecutionScriptProgram) =>
-                  val newOpCount = calcOpCount(opCount, OP_CHECKMULTISIGVERIFY) + BitcoinScriptUtil
-                    .numPossibleSignaturesOnStack(program)
-                    .toInt
-                  loop(newProgram, newOpCount)
-              }
-            //reserved operations
-            case OP_NOP :: t =>
-              //script discourage upgradeable flag does not apply to a OP_NOP
-              loop(ScriptProgram(p, p.stack, t), calcOpCount(opCount, OP_NOP))
+              //crypto operations
+              case OP_HASH160 :: _ =>
+                loop(CryptoInterpreter.opHash160(p),
+                     calcOpCount(opCount, OP_HASH160))
+              case OP_CHECKSIG :: _ =>
+                loop(CryptoInterpreter.opCheckSig(p),
+                     calcOpCount(opCount, OP_CHECKSIG))
+              case OP_CHECKSIGVERIFY :: _ =>
+                loop(CryptoInterpreter.opCheckSigVerify(p),
+                     calcOpCount(opCount, OP_CHECKSIGVERIFY))
+              case OP_SHA1 :: _ =>
+                loop(CryptoInterpreter.opSha1(p), calcOpCount(opCount, OP_SHA1))
+              case OP_RIPEMD160 :: _ =>
+                loop(CryptoInterpreter.opRipeMd160(p),
+                     calcOpCount(opCount, OP_RIPEMD160))
+              case OP_SHA256 :: _ =>
+                loop(CryptoInterpreter.opSha256(p),
+                     calcOpCount(opCount, OP_SHA256))
+              case OP_HASH256 :: _ =>
+                loop(CryptoInterpreter.opHash256(p),
+                     calcOpCount(opCount, OP_HASH256))
+              case OP_CODESEPARATOR :: _ =>
+                loop(CryptoInterpreter.opCodeSeparator(p),
+                     calcOpCount(opCount, OP_CODESEPARATOR))
+              case OP_CHECKMULTISIG :: _ =>
+                CryptoInterpreter.opCheckMultiSig(p) match {
+                  case newProgram: ExecutedScriptProgram =>
+                    //script was marked invalid for other reasons, don't need to update the opcount
+                    loop(newProgram, opCount)
+                  case newProgram @ (_: ExecutionInProgressScriptProgram |
+                      _: PreExecutionScriptProgram) =>
+                    val newOpCount = calcOpCount(opCount, OP_CHECKMULTISIG) + BitcoinScriptUtil
+                      .numPossibleSignaturesOnStack(program)
+                      .toInt
+                    loop(newProgram, newOpCount)
+                }
+              case OP_CHECKMULTISIGVERIFY :: _ =>
+                CryptoInterpreter.opCheckMultiSigVerify(p) match {
+                  case newProgram: ExecutedScriptProgram =>
+                    //script was marked invalid for other reasons, don't need to update the opcount
+                    loop(newProgram, opCount)
+                  case newProgram @ (_: ExecutionInProgressScriptProgram |
+                      _: PreExecutionScriptProgram) =>
+                    val newOpCount = calcOpCount(
+                      opCount,
+                      OP_CHECKMULTISIGVERIFY) + BitcoinScriptUtil
+                      .numPossibleSignaturesOnStack(program)
+                      .toInt
+                    loop(newProgram, newOpCount)
+                }
+              //reserved operations
+              case OP_NOP :: t =>
+                //script discourage upgradeable flag does not apply to a OP_NOP
+                loop(ScriptProgram(p, p.stack, t), calcOpCount(opCount, OP_NOP))
 
-            //if we see an OP_NOP and the DISCOURAGE_UPGRADABLE_OP_NOPS flag is set we must fail our program
-            case (nop: NOP) :: _
-                if ScriptFlagUtil.discourageUpgradableNOPs(p.flags) =>
-              logger.error(
-                "We cannot execute a NOP when the ScriptVerifyDiscourageUpgradableNOPs is set")
-              loop(ScriptProgram(p, ScriptErrorDiscourageUpgradableNOPs),
-                   calcOpCount(opCount, nop))
-            case (nop: NOP) :: t =>
-              loop(ScriptProgram(p, p.stack, t), calcOpCount(opCount, nop))
-            case OP_RESERVED :: _ =>
-              logger.error(
-                "OP_RESERVED automatically marks transaction invalid")
-              loop(ScriptProgram(p, ScriptErrorBadOpCode),
-                   calcOpCount(opCount, OP_RESERVED))
-            case OP_VER :: _ =>
-              logger.error("Transaction is invalid when executing OP_VER")
-              loop(ScriptProgram(p, ScriptErrorBadOpCode),
-                   calcOpCount(opCount, OP_VER))
-            case OP_RESERVED1 :: _ =>
-              logger.error("Transaction is invalid when executing OP_RESERVED1")
-              loop(ScriptProgram(p, ScriptErrorBadOpCode),
-                   calcOpCount(opCount, OP_RESERVED1))
-            case OP_RESERVED2 :: _ =>
-              logger.error("Transaction is invalid when executing OP_RESERVED2")
-              loop(ScriptProgram(p, ScriptErrorBadOpCode),
-                   calcOpCount(opCount, OP_RESERVED2))
-
-            case (reservedOperation: ReservedOperation) :: _ =>
-              logger.error(
-                "Undefined operation found which automatically fails the script: " + reservedOperation)
-              loop(ScriptProgram(p, ScriptErrorBadOpCode),
-                   calcOpCount(opCount, reservedOperation))
-            //splice operations
-            case OP_SIZE :: _ =>
-              loop(SpliceInterpreter.opSize(p), calcOpCount(opCount, OP_SIZE))
-
-            //locktime operations
-            case OP_CHECKLOCKTIMEVERIFY :: _ =>
-              //check if CLTV is enforced yet
-              if (ScriptFlagUtil.checkLockTimeVerifyEnabled(p.flags)) {
-                loop(LockTimeInterpreter.opCheckLockTimeVerify(p),
-                     calcOpCount(opCount, OP_CHECKLOCKTIMEVERIFY))
-              } //if not, check to see if we should discourage p
-              else if (ScriptFlagUtil.discourageUpgradableNOPs(p.flags)) {
+              //if we see an OP_NOP and the DISCOURAGE_UPGRADABLE_OP_NOPS flag is set we must fail our program
+              case (nop: NOP) :: _
+                  if ScriptFlagUtil.discourageUpgradableNOPs(p.flags) =>
                 logger.error(
                   "We cannot execute a NOP when the ScriptVerifyDiscourageUpgradableNOPs is set")
                 loop(ScriptProgram(p, ScriptErrorDiscourageUpgradableNOPs),
-                     calcOpCount(opCount, OP_CHECKLOCKTIMEVERIFY))
-              } //in this case, just reat OP_CLTV just like a NOP and remove it from the stack
-              else
-                loop(ScriptProgram(p, p.script.tail, ScriptProgram.Script),
-                     calcOpCount(opCount, OP_CHECKLOCKTIMEVERIFY))
-            case OP_CHECKSEQUENCEVERIFY :: _ =>
-              //check if CLTV is enforced yet
-              if (ScriptFlagUtil.checkSequenceVerifyEnabled(p.flags)) {
-                loop(LockTimeInterpreter.opCheckSequenceVerify(p),
-                     calcOpCount(opCount, OP_CHECKSEQUENCEVERIFY))
-              } //if not, check to see if we should discourage p
-              else if (ScriptFlagUtil.discourageUpgradableNOPs(p.flags)) {
+                     calcOpCount(opCount, nop))
+              case (nop: NOP) :: t =>
+                loop(ScriptProgram(p, p.stack, t), calcOpCount(opCount, nop))
+              case OP_RESERVED :: _ =>
                 logger.error(
-                  "We cannot execute a NOP when the ScriptVerifyDiscourageUpgradableNOPs is set")
-                loop(ScriptProgram(p, ScriptErrorDiscourageUpgradableNOPs),
-                     calcOpCount(opCount, OP_CHECKSEQUENCEVERIFY))
-              } //in this case, just read OP_CSV just like a NOP and remove it from the stack
-              else
-                loop(ScriptProgram(p, p.script.tail, ScriptProgram.Script),
-                     calcOpCount(opCount, OP_CHECKSEQUENCEVERIFY))
-            //no more script operations to run, return whether the program is valid and the final state of the program
-            case Nil    => loop(ScriptProgram.toExecutedProgram(p), opCount)
-            case h :: _ => throw new RuntimeException(s"$h was unmatched")
-          }
-      }
+                  "OP_RESERVED automatically marks transaction invalid")
+                loop(ScriptProgram(p, ScriptErrorBadOpCode),
+                     calcOpCount(opCount, OP_RESERVED))
+              case OP_VER :: _ =>
+                logger.error("Transaction is invalid when executing OP_VER")
+                loop(ScriptProgram(p, ScriptErrorBadOpCode),
+                     calcOpCount(opCount, OP_VER))
+              case OP_RESERVED1 :: _ =>
+                logger.error(
+                  "Transaction is invalid when executing OP_RESERVED1")
+                loop(ScriptProgram(p, ScriptErrorBadOpCode),
+                     calcOpCount(opCount, OP_RESERVED1))
+              case OP_RESERVED2 :: _ =>
+                logger.error(
+                  "Transaction is invalid when executing OP_RESERVED2")
+                loop(ScriptProgram(p, ScriptErrorBadOpCode),
+                     calcOpCount(opCount, OP_RESERVED2))
+
+              case (reservedOperation: ReservedOperation) :: _ =>
+                logger.error(
+                  "Undefined operation found which automatically fails the script: " + reservedOperation)
+                loop(ScriptProgram(p, ScriptErrorBadOpCode),
+                     calcOpCount(opCount, reservedOperation))
+              //splice operations
+              case OP_SIZE :: _ =>
+                loop(SpliceInterpreter.opSize(p), calcOpCount(opCount, OP_SIZE))
+
+              //locktime operations
+              case OP_CHECKLOCKTIMEVERIFY :: _ =>
+                //check if CLTV is enforced yet
+                if (ScriptFlagUtil.checkLockTimeVerifyEnabled(p.flags)) {
+                  loop(LockTimeInterpreter.opCheckLockTimeVerify(p),
+                       calcOpCount(opCount, OP_CHECKLOCKTIMEVERIFY))
+                } //if not, check to see if we should discourage p
+                else if (ScriptFlagUtil.discourageUpgradableNOPs(p.flags)) {
+                  logger.error(
+                    "We cannot execute a NOP when the ScriptVerifyDiscourageUpgradableNOPs is set")
+                  loop(ScriptProgram(p, ScriptErrorDiscourageUpgradableNOPs),
+                       calcOpCount(opCount, OP_CHECKLOCKTIMEVERIFY))
+                } //in this case, just reat OP_CLTV just like a NOP and remove it from the stack
+                else
+                  loop(ScriptProgram(p, p.script.tail, ScriptProgram.Script),
+                       calcOpCount(opCount, OP_CHECKLOCKTIMEVERIFY))
+              case OP_CHECKSEQUENCEVERIFY :: _ =>
+                //check if CLTV is enforced yet
+                if (ScriptFlagUtil.checkSequenceVerifyEnabled(p.flags)) {
+                  loop(LockTimeInterpreter.opCheckSequenceVerify(p),
+                       calcOpCount(opCount, OP_CHECKSEQUENCEVERIFY))
+                } //if not, check to see if we should discourage p
+                else if (ScriptFlagUtil.discourageUpgradableNOPs(p.flags)) {
+                  logger.error(
+                    "We cannot execute a NOP when the ScriptVerifyDiscourageUpgradableNOPs is set")
+                  loop(ScriptProgram(p, ScriptErrorDiscourageUpgradableNOPs),
+                       calcOpCount(opCount, OP_CHECKSEQUENCEVERIFY))
+                } //in this case, just read OP_CSV just like a NOP and remove it from the stack
+                else
+                  loop(ScriptProgram(p, p.script.tail, ScriptProgram.Script),
+                       calcOpCount(opCount, OP_CHECKSEQUENCEVERIFY))
+              //no more script operations to run, return whether the program is valid and the final state of the program
+              case Nil    => loop(ScriptProgram.toExecutedProgram(p), opCount)
+              case h :: _ => throw new RuntimeException(s"$h was unmatched")
+            }
+        }
     }
   }
 
@@ -782,13 +834,11 @@ sealed abstract class ScriptInterpreter {
     val prevOutputs = transaction.inputs.map(_.previousOutput)
     val noDuplicateInputs = prevOutputs.distinct.size == prevOutputs.size
 
-    val isValidScriptSigForCoinbaseTx = transaction.isCoinbase match {
-      case true =>
-        transaction.inputs.head.scriptSignature.asmBytes.size >= 2 &&
-          transaction.inputs.head.scriptSignature.asmBytes.size <= 100
-      case false =>
-        //since this is not a coinbase tx we cannot have any empty previous outs inside of inputs
-        !transaction.inputs.exists(_.previousOutput == EmptyTransactionOutPoint)
+    val isValidScriptSigForCoinbaseTx = if (transaction.isCoinbase) {
+      transaction.inputs.head.scriptSignature.asmBytes.size >= 2 &&
+      transaction.inputs.head.scriptSignature.asmBytes.size <= 100
+    } else {
+      !transaction.inputs.exists(_.previousOutput == EmptyTransactionOutPoint)
     }
     inputOutputsNotZero && txNotLargerThanBlock && outputsSpendValidAmountsOfMoney &&
     allOutputsValidMoneyRange && noDuplicateInputs && isValidScriptSigForCoinbaseTx
@@ -802,9 +852,10 @@ sealed abstract class ScriptInterpreter {
   /**  Calculates the new op count after the execution of the given
     * [[org.bitcoins.core.script.constant.ScriptToken ScriptToken]] */
   private def calcOpCount(oldOpCount: Int, token: ScriptToken): Int =
-    BitcoinScriptUtil.countsTowardsScriptOpLimit(token) match {
-      case true  => oldOpCount + 1
-      case false => oldOpCount
+    if (BitcoinScriptUtil.countsTowardsScriptOpLimit(token)) {
+      oldOpCount + 1
+    } else {
+      oldOpCount
     }
 
   /**
@@ -826,7 +877,10 @@ sealed abstract class ScriptInterpreter {
         }
       case _: WitnessTxSigComponentRaw => false
       case w: WitnessTxSigComponentP2SH =>
-        !w.scriptSignature.redeemScript.isInstanceOf[WitnessScriptPubKey]
+        w.scriptSignature.redeemScript match {
+          case _: WitnessScriptPubKey => false
+          case _                      => true
+        }
       case r: WitnessTxSigComponentRebuilt =>
         r.transaction.witness
           .witnesses(txSigComponent.inputIndex.toInt)

--- a/core/src/main/scala/org/bitcoins/core/script/locktime/LockTimeInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/locktime/LockTimeInterpreter.scala
@@ -2,7 +2,11 @@ package org.bitcoins.core.script.locktime
 
 import org.bitcoins.core.number.{Int64, UInt32}
 import org.bitcoins.core.protocol.transaction.TransactionConstants
-import org.bitcoins.core.script.ScriptProgram
+import org.bitcoins.core.script.{
+  ExecutionInProgressScriptProgram,
+  ScriptProgram,
+  StartedScriptProgram
+}
 import org.bitcoins.core.script.constant.{
   ScriptConstant,
   ScriptNumber,
@@ -32,7 +36,8 @@ sealed abstract class LockTimeInterpreter {
     * The precise semantics are described in BIP 0065
     */
   @tailrec
-  final def opCheckLockTimeVerify(program: ScriptProgram): ScriptProgram = {
+  final def opCheckLockTimeVerify(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_CHECKLOCKTIMEVERIFY),
             "Script top must be OP_CHECKLOCKTIMEVERIFY")
     val input = program.txSignatureComponent.transaction
@@ -98,7 +103,8 @@ sealed abstract class LockTimeInterpreter {
     * See [[https://github.com/bitcoin/bips/blob/master/bip-0112.mediawiki BIP112]] for more information
     */
   @tailrec
-  final def opCheckSequenceVerify(program: ScriptProgram): ScriptProgram = {
+  final def opCheckSequenceVerify(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     if (program.stack.isEmpty) {
       logger.error("Cannot execute OP_CHECKSEQUENCEVERIFY on an empty stack")
       ScriptProgram(program, ScriptErrorInvalidStackOperation)

--- a/core/src/main/scala/org/bitcoins/core/script/splice/SpliceInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/splice/SpliceInterpreter.scala
@@ -1,6 +1,10 @@
 package org.bitcoins.core.script.splice
 
-import org.bitcoins.core.script.ScriptProgram
+import org.bitcoins.core.script.{
+  ExecutionInProgressScriptProgram,
+  ScriptProgram,
+  StartedScriptProgram
+}
 import org.bitcoins.core.script.constant._
 import org.bitcoins.core.script.result.ScriptErrorInvalidStackOperation
 import org.bitcoins.core.util.BitcoinSLogger
@@ -13,7 +17,8 @@ sealed abstract class SpliceInterpreter {
   private def logger = BitcoinSLogger.logger
 
   /** Pushes the string length of the top element of the stack (without popping it). */
-  def opSize(program: ScriptProgram): ScriptProgram = {
+  def opSize(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_SIZE),
             "Script top must be OP_SIZE")
     if (program.stack.nonEmpty) {

--- a/core/src/main/scala/org/bitcoins/core/script/stack/StackInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/stack/StackInterpreter.scala
@@ -1,6 +1,10 @@
 package org.bitcoins.core.script.stack
 
-import org.bitcoins.core.script.ScriptProgram
+import org.bitcoins.core.script.{
+  ExecutionInProgressScriptProgram,
+  ScriptProgram,
+  StartedScriptProgram
+}
 import org.bitcoins.core.script.constant._
 import org.bitcoins.core.script.flag.ScriptFlagUtil
 import org.bitcoins.core.script.result._
@@ -20,7 +24,7 @@ sealed abstract class StackInterpreter {
     * Duplicates the element on top of the stack
     * expects the first element in script to be the OP_DUP operation.
     */
-  def opDup(program: ScriptProgram): ScriptProgram = {
+  def opDup(program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_DUP),
             "Top of the script stack must be OP_DUP")
     program.stack match {
@@ -33,7 +37,8 @@ sealed abstract class StackInterpreter {
   }
 
   /** If the top stack value is not 0, duplicate it. */
-  def opIfDup(program: ScriptProgram): ScriptProgram = {
+  def opIfDup(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_IFDUP),
             "Top of the script stack must be OP_DUP")
     if (program.stack.nonEmpty) {
@@ -49,7 +54,8 @@ sealed abstract class StackInterpreter {
   }
 
   /** Puts the number of stack items onto the stack. */
-  def opDepth(program: ScriptProgram): ScriptProgram = {
+  def opDepth(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_DEPTH),
             "Top of script stack must be OP_DEPTH")
     val stackSize = program.stack.size
@@ -58,7 +64,8 @@ sealed abstract class StackInterpreter {
   }
 
   /** Puts the input onto the top of the alt stack. Removes it from the main stack. */
-  def opToAltStack(program: ScriptProgram): ScriptProgram = {
+  def opToAltStack(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_TOALTSTACK),
             "Top of script stack must be OP_TOALTSTACK")
     if (program.stack.nonEmpty) {
@@ -73,7 +80,8 @@ sealed abstract class StackInterpreter {
   }
 
   /** Puts the input onto the top of the main stack. Removes it from the alt stack. */
-  def opFromAltStack(program: ScriptProgram): ScriptProgram = {
+  def opFromAltStack(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_FROMALTSTACK),
             "Top of script stack must be OP_FROMALTSTACK")
     if (program.altStack.nonEmpty) {
@@ -89,7 +97,8 @@ sealed abstract class StackInterpreter {
   }
 
   /** Removes the top stack item. */
-  def opDrop(program: ScriptProgram): ScriptProgram = {
+  def opDrop(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_DROP),
             "Top of script stack must be OP_DROP")
     if (program.stack.nonEmpty) {
@@ -101,7 +110,7 @@ sealed abstract class StackInterpreter {
   }
 
   /** Removes the second-to-top stack item. */
-  def opNip(program: ScriptProgram): ScriptProgram = {
+  def opNip(program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_NIP),
             "Top of script stack must be OP_NIP")
     program.stack match {
@@ -116,7 +125,8 @@ sealed abstract class StackInterpreter {
   }
 
   /** Copies the second-to-top stack item to the top. */
-  def opOver(program: ScriptProgram): ScriptProgram = {
+  def opOver(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_OVER),
             "Top of script stack must be OP_OVER")
     program.stack match {
@@ -132,7 +142,8 @@ sealed abstract class StackInterpreter {
   }
 
   /** The item n back in the stack is copied to the top. */
-  def opPick(program: ScriptProgram): ScriptProgram = {
+  def opPick(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_PICK),
             "Top of script stack must be OP_PICK")
     executeOpWithStackTopAsNumberArg(
@@ -155,7 +166,8 @@ sealed abstract class StackInterpreter {
   }
 
   /** The item n back in the stack is moved to the top. */
-  def opRoll(program: ScriptProgram): ScriptProgram = {
+  def opRoll(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_ROLL),
             "Top of script stack must be OP_ROLL")
     executeOpWithStackTopAsNumberArg(
@@ -181,7 +193,7 @@ sealed abstract class StackInterpreter {
     * The top three items on the stack are rotated to the left.
     * Ex: x1 x2 x3 -> x2 x3 x1
     */
-  def opRot(program: ScriptProgram): ScriptProgram = {
+  def opRot(program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_ROT),
             "Top of script stack must be OP_ROT")
     program.stack match {
@@ -198,7 +210,8 @@ sealed abstract class StackInterpreter {
     * The fifth and sixth items back are moved to the top of the stack.
     * Ex. x1 x2 x3 x4 x5 x6 -> x3 x4 x5 x6 x1 x2
     */
-  def op2Rot(program: ScriptProgram): ScriptProgram = {
+  def op2Rot(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_2ROT),
             "Top of script stack must be OP_2ROT")
     program.stack match {
@@ -212,7 +225,8 @@ sealed abstract class StackInterpreter {
   }
 
   /** Removes the top two stack items. */
-  def op2Drop(program: ScriptProgram): ScriptProgram = {
+  def op2Drop(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_2DROP),
             "Top of script stack must be OP_2DROP")
     if (program.stack.size > 1) {
@@ -224,7 +238,8 @@ sealed abstract class StackInterpreter {
   }
 
   /** The top two items on the stack are swapped. */
-  def opSwap(program: ScriptProgram): ScriptProgram = {
+  def opSwap(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_SWAP),
             "Top of script stack must be OP_SWAP")
     if (program.stack.size > 1) {
@@ -237,7 +252,8 @@ sealed abstract class StackInterpreter {
   }
 
   /** The item at the top of the stack is copied and inserted before the second-to-top item. */
-  def opTuck(program: ScriptProgram): ScriptProgram = {
+  def opTuck(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_TUCK),
             "Top of script stack must be OP_TUCK")
     program.stack match {
@@ -251,7 +267,8 @@ sealed abstract class StackInterpreter {
   }
 
   /** Duplicates the top two stack items. */
-  def op2Dup(program: ScriptProgram): ScriptProgram = {
+  def op2Dup(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_2DUP),
             "Top of script stack must be OP_2DUP")
     program.stack match {
@@ -265,7 +282,8 @@ sealed abstract class StackInterpreter {
   }
 
   /** Duplicates the top three stack items. */
-  def op3Dup(program: ScriptProgram): ScriptProgram = {
+  def op3Dup(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_3DUP),
             "Top of script stack must be OP_3DUP")
     program.stack match {
@@ -279,7 +297,8 @@ sealed abstract class StackInterpreter {
   }
 
   /** Copies the pair of items two spaces back in the stack to the front. */
-  def op2Over(program: ScriptProgram): ScriptProgram = {
+  def op2Over(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_2OVER),
             "Top of script stack must be OP_2OVER")
     program.stack match {
@@ -293,7 +312,8 @@ sealed abstract class StackInterpreter {
   }
 
   /** Swaps the top two pairs of items. */
-  def op2Swap(program: ScriptProgram): ScriptProgram = {
+  def op2Swap(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_2SWAP),
             "Top of script stack must be OP_2SWAP")
     program.stack match {
@@ -313,8 +333,8 @@ sealed abstract class StackInterpreter {
     * @return the program with the result of the op pushed onto to the top of the stack
     */
   private def executeOpWithStackTopAsNumberArg(
-      program: ScriptProgram,
-      op: ScriptNumber => ScriptProgram): ScriptProgram = {
+      program: ExecutionInProgressScriptProgram,
+      op: ScriptNumber => StartedScriptProgram): StartedScriptProgram = {
     program.stack.head match {
       case scriptNum: ScriptNumber => op(scriptNum)
       case _: ScriptToken          =>

--- a/core/src/main/scala/org/bitcoins/core/serializers/p2p/RawNetworkMessageSerializer.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/p2p/RawNetworkMessageSerializer.scala
@@ -8,13 +8,14 @@ trait RawNetworkMessageSerializer extends RawBitcoinSerializer[NetworkMessage] {
 
   def read(bytes: ByteVector): NetworkMessage = {
     //first 24 bytes are the header
-    val (headerBytes,payloadBytes) = bytes.splitAt(24)
+    val (headerBytes, payloadBytes) = bytes.splitAt(24)
     val header = NetworkHeader.fromBytes(headerBytes)
     if (header.payloadSize.toInt > payloadBytes.length) {
-      throw new RuntimeException(s"We do not have enough bytes for payload! Expected=${header.payloadSize.toInt} got=${payloadBytes.length}")
+      throw new RuntimeException(
+        s"We do not have enough bytes for payload! Expected=${header.payloadSize.toInt} got=${payloadBytes.length}")
     } else {
       val payload = NetworkPayload(header, payloadBytes)
-      val n  = NetworkMessage(header, payload)
+      val n = NetworkMessage(header, payload)
       n
     }
   }

--- a/core/src/main/scala/org/bitcoins/core/serializers/p2p/headers/RawNetworkHeaderSerializer.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/p2p/headers/RawNetworkHeaderSerializer.scala
@@ -21,7 +21,9 @@ trait RawNetworkHeaderSerializer
     * @return the native object for the MessageHeader
     */
   def read(bytes: ByteVector): NetworkHeader = {
-    require(bytes.length == 24, s"Got bytes.length=${bytes.length} when NetworkHeader expects 24 bytes")
+    require(
+      bytes.length == 24,
+      s"Got bytes.length=${bytes.length} when NetworkHeader expects 24 bytes")
     val network = Networks.magicToNetwork(bytes.take(4))
     //.trim removes the null characters appended to the command name
     val commandName = bytes.slice(4, 16).toArray.map(_.toChar).mkString.trim

--- a/core/src/main/scala/org/bitcoins/core/serializers/p2p/headers/RawNetworkHeaderSerializer.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/p2p/headers/RawNetworkHeaderSerializer.scala
@@ -21,6 +21,7 @@ trait RawNetworkHeaderSerializer
     * @return the native object for the MessageHeader
     */
   def read(bytes: ByteVector): NetworkHeader = {
+    require(bytes.length == 24, s"Got bytes.length=${bytes.length} when NetworkHeader expects 24 bytes")
     val network = Networks.magicToNetwork(bytes.take(4))
     //.trim removes the null characters appended to the command name
     val commandName = bytes.slice(4, 16).toArray.map(_.toChar).mkString.trim

--- a/docs/rpc/bitcoind.md
+++ b/docs/rpc/bitcoind.md
@@ -18,13 +18,14 @@ import scala.concurrent._
 import org.bitcoins.{rpc, core}
 import core.currency.Bitcoins
 import rpc.client.common._
+import java.io._
 
 implicit val ec: ExecutionContext = ExecutionContext.global
 
 // this reads authentication credentials and
 // connection details from the default data
 // directory on your platform
-val client = BitcoindRpcClient.fromDatadir()
+val client = BitcoindRpcClient.fromDatadir(binary=new File("/path/to/bitcoind"), datadir=new File("/path/to/bitcoind-datadir"))
 
 val balance: Future[Bitcoins] = for {
   _ <- client.start()
@@ -98,6 +99,7 @@ import org.bitcoins.rpc.BitcoindWalletException
 import org.bitcoins.core.crypto._
 import org.bitcoins.core.protocol._
 import org.bitcoins.core.currency._
+import java.io._
 
 import scala.concurrent._
 
@@ -105,7 +107,7 @@ implicit val ec = ExecutionContext.global
 
 // let's assume you have an already running client,
 // so there's no need to start this one
-val cli = BitcoindRpcClient.fromDatadir()
+val cli = BitcoindRpcClient.fromDatadir(binary=new File("/path/to/bitcoind"), datadir=new File("/path/to/bitcoind-datadir"))
 
 // let's also assume you have a bitcoin address
 val address: BitcoinAddress = ???

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
@@ -12,7 +12,6 @@ import org.scalatest.{DoNotDiscover, FutureOutcome}
 import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
 
-@DoNotDiscover
 class NeutrinoNodeTest extends NodeUnitTest {
 
   /** Wallet config with data directory set to user temp directory */

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
@@ -5,6 +5,7 @@ import org.bitcoins.rpc.client.common.BitcoindVersion
 import org.bitcoins.rpc.util.RpcUtil
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.BitcoinSTestAppConfig
+import org.bitcoins.testkit.fixtures.UsesExperimentalBitcoind
 import org.bitcoins.testkit.node.fixture.NeutrinoNodeConnectedWithBitcoind
 import org.bitcoins.testkit.node.{NodeTestUtil, NodeUnitTest}
 import org.scalatest.{DoNotDiscover, FutureOutcome}
@@ -12,6 +13,7 @@ import org.scalatest.{DoNotDiscover, FutureOutcome}
 import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
 
+@DoNotDiscover
 class NeutrinoNodeTest extends NodeUnitTest {
 
   /** Wallet config with data directory set to user temp directory */
@@ -26,7 +28,7 @@ class NeutrinoNodeTest extends NodeUnitTest {
 
   behavior of "NeutrinoNode"
 
-  it must "receive notification that a block occurred on the p2p network" in {
+  it must "receive notification that a block occurred on the p2p network" taggedAs (UsesExperimentalBitcoind) in {
     nodeConnectedWithBitcoind: NeutrinoNodeConnectedWithBitcoind =>
       val node = nodeConnectedWithBitcoind.node
       val bitcoind = nodeConnectedWithBitcoind.bitcoind
@@ -54,7 +56,7 @@ class NeutrinoNodeTest extends NodeUnitTest {
       }
   }
 
-  it must "stay in sync with a bitcoind instance" in {
+  it must "stay in sync with a bitcoind instance" taggedAs (UsesExperimentalBitcoind) in {
     nodeConnectedWithBitcoind: NeutrinoNodeConnectedWithBitcoind =>
       val node = nodeConnectedWithBitcoind.node
       val bitcoind = nodeConnectedWithBitcoind.bitcoind

--- a/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
+++ b/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
@@ -57,6 +57,15 @@ case class NodeAppConfig(
   lazy val isNeutrinoEnabled: Boolean = config
     .getString("node.mode")
     .toLowerCase == "neutrino"
+
+  /**
+    * List of peers
+    */
+  lazy val peers: Vector[String] = {
+    val list = config.getStringList("node.peers")
+    0.until(list.size())
+      .foldLeft(Vector.empty[String])((acc, i) => acc :+ list.get(i))
+  }
 }
 
 object NodeAppConfig {

--- a/node/src/main/scala/org/bitcoins/node/networking/P2PClient.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/P2PClient.scala
@@ -377,9 +377,8 @@ object P2PClient extends P2PLogger {
         val messageTry = Try(NetworkMessage(remainingBytes))
         messageTry match {
           case Success(message) =>
-            val newRemainingBytes = remainingBytes.slice(
-              message.bytes.length,
-              remainingBytes.length)
+            val newRemainingBytes =
+              remainingBytes.slice(message.bytes.length, remainingBytes.length)
             logger.trace(
               s"Parsed a message=${message.header.commandName} from bytes, continuing with remainingBytes=${newRemainingBytes.length}")
             loop(newRemainingBytes, message :: accum)

--- a/node/src/main/scala/org/bitcoins/node/networking/P2PClient.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/P2PClient.scala
@@ -377,22 +377,12 @@ object P2PClient extends P2PLogger {
         val messageTry = Try(NetworkMessage(remainingBytes))
         messageTry match {
           case Success(message) =>
-            val expectedPayloadSize = message.header.payloadSize.toInt
-            val actualPayloadSize = message.payload.bytes.size
-            if (expectedPayloadSize != actualPayloadSize) {
-              //this means our tcp frame was not aligned, therefore put the message back in the
-              //buffer and wait for the remaining bytes
-              logger.trace(
-                s"TCP frame not aligned, payload sizes differed. Expected=$expectedPayloadSize, actual=$actualPayloadSize")
-              (accum.reverse, remainingBytes)
-            } else {
-              val newRemainingBytes = remainingBytes.slice(
-                message.bytes.length,
-                remainingBytes.length)
-              logger.trace(
-                s"Parsed a message=${message.header.commandName} from bytes, continuing with remainingBytes=${newRemainingBytes.length}")
-              loop(newRemainingBytes, message :: accum)
-            }
+            val newRemainingBytes = remainingBytes.slice(
+              message.bytes.length,
+              remainingBytes.length)
+            logger.trace(
+              s"Parsed a message=${message.header.commandName} from bytes, continuing with remainingBytes=${newRemainingBytes.length}")
+            loop(newRemainingBytes, message :: accum)
           case Failure(exc) =>
             logger.trace(
               s"Failed to parse network message, could be because TCP frame isn't aligned: $exc")

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -157,7 +157,7 @@ case class DataMessageHandler(
               }
 
               if (count.toInt == HeadersMessage.MaxHeadersCount) {
-                logger.error(
+                logger.info(
                   s"Received maximum amount of headers in one header message. This means we are not synced, requesting more")
                 peerMsgSender
                   .sendGetHeadersMessage(lastHash)

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -225,7 +225,7 @@ case class DataMessageHandler(
       res <- nextRangeOpt match {
         case Some((startHeight, stopHash)) =>
           logger.info(
-            s"Requesting compact filter headers from=$startHeight to=$stopHash")
+            s"Requesting compact filter headers from=$startHeight to=${stopHash.flip}")
           peerMsgSender
             .sendGetCompactFilterHeadersMessage(startHeight, stopHash)
             .map(_ => true)
@@ -259,7 +259,7 @@ case class DataMessageHandler(
       res <- nextRangeOpt match {
         case Some((startHeight, stopHash)) =>
           logger.info(
-            s"Requesting compact filters from=$startHeight to=$stopHash")
+            s"Requesting compact filters from=$startHeight to=${stopHash.flip}")
           peerMsgSender
             .sendGetCompactFiltersMessage(startHeight, stopHash)
             .map(_ => true)

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -36,8 +36,18 @@ object CommonSettings {
     apiURL := homepage.value.map(_.toString + "/api").map(url(_)),
     // scaladoc settings end
     ////
+
     scalacOptions in Compile := compilerOpts(scalaVersion.value),
+    //remove annoying import unused things in the scala console
+    //https://stackoverflow.com/questions/26940253/in-sbt-how-do-you-override-scalacoptions-for-console-in-all-configurations
+    scalacOptions in (Compile, console) ~= (_ filterNot (s =>
+      s == "-Ywarn-unused-import"
+        || s =="-Ywarn-unused"
+        //for 2.13 -- they use different compiler opts
+        || s == "-Xlint:unused")),
+    scalacOptions in (Test, console) := (scalacOptions in (Compile, console)).value,
     scalacOptions in Test := testCompilerOpts,
+
     Compile / compile / javacOptions ++= {
       if (isCI) {
         //jdk11 is used on CI, we need to use the --release flag to make sure

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -48,7 +48,7 @@ object Deps {
 
     // CLI deps
     val scoptV = "4.0.0-RC2"
-    val sttpV = "1.6.6"
+    val sttpV = "1.6.8"
   }
 
   object Compile {

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -48,7 +48,7 @@ object Deps {
 
     // CLI deps
     val scoptV = "4.0.0-RC2"
-    val sttpV = "1.6.8"
+    val sttpV = "1.7.0"
   }
 
   object Compile {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,7 +18,7 @@ addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.0")
 
 // bloop is a build server, enabling faster builds and more rapid dev feedback
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.3.3")
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.3.4")
 
 //tool to publish snapshots to sonatype after CI builds finish
 //https://github.com/olafurpg/sbt-ci-release

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -22,7 +22,7 @@ addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.3.4")
 
 //tool to publish snapshots to sonatype after CI builds finish
 //https://github.com/olafurpg/sbt-ci-release
-addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.3.2")
+addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.4.31")
 
 // write markdown files with type-checked Scala
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "1.3.2")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,7 +18,7 @@ addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.0")
 
 // bloop is a build server, enabling faster builds and more rapid dev feedback
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.3.2")
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.3.3")
 
 //tool to publish snapshots to sonatype after CI builds finish
 //https://github.com/olafurpg/sbt-ci-release

--- a/testkit/src/main/scala/org/bitcoins/testkit/eclair/rpc/EclairRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/eclair/rpc/EclairRpcTestUtil.scala
@@ -627,7 +627,8 @@ trait EclairRpcTestUtil extends BitcoinSLogger {
         network = instance.network,
         uri = new URI("http://localhost:18333"),
         rpcUri = auth.bitcoindRpcUri,
-        authCredentials = auth.bitcoinAuthOpt.get
+        authCredentials = auth.bitcoinAuthOpt.get,
+        binary = BitcoindRpcTestUtil.newestBitcoindBinary
       )
       BitcoindRpcClient.withActorSystem(bitcoindInstance)
     }

--- a/testkit/src/main/scala/org/bitcoins/testkit/eclair/rpc/EclairRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/eclair/rpc/EclairRpcTestUtil.scala
@@ -19,7 +19,7 @@ import org.bitcoins.eclair.rpc.api.EclairApi
 import org.bitcoins.eclair.rpc.client.EclairRpcClient
 import org.bitcoins.eclair.rpc.config.EclairInstance
 import org.bitcoins.eclair.rpc.json.{PaymentId, PaymentStatus}
-import org.bitcoins.rpc.client.common.BitcoindRpcClient
+import org.bitcoins.rpc.client.common.{BitcoindRpcClient, BitcoindVersion}
 import org.bitcoins.rpc.config.BitcoindInstance
 import org.bitcoins.rpc.util.RpcUtil
 import org.bitcoins.testkit.async.TestAsyncUtil
@@ -628,7 +628,7 @@ trait EclairRpcTestUtil extends BitcoinSLogger {
         uri = new URI("http://localhost:18333"),
         rpcUri = auth.bitcoindRpcUri,
         authCredentials = auth.bitcoinAuthOpt.get,
-        binary = BitcoindRpcTestUtil.newestBitcoindBinary
+        binary = BitcoindRpcTestUtil.getBinary(BitcoindVersion.V17)
       )
       BitcoindRpcClient.withActorSystem(bitcoindInstance)
     }

--- a/testkit/src/main/scala/org/bitcoins/testkit/fixtures/BitcoinSFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/fixtures/BitcoinSFixture.scala
@@ -9,6 +9,8 @@ import org.scalatest._
 import scala.concurrent.{Future, Promise}
 import scala.util.{Failure, Success}
 
+object UsesExperimentalBitcoind extends Tag("UsesExperimentalBitcoind")
+
 trait BitcoinSFixture extends BitcoinSAsyncFixtureTest {
 
   /**

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
@@ -173,7 +173,7 @@ trait BitcoindRpcTestUtil extends BitcoinSLogger {
 
   def newestBitcoindBinary: File = getBinary(BitcoindVersion.newest)
 
-  private def getBinary(version: BitcoindVersion): File = version match {
+  def getBinary(version: BitcoindVersion): File = version match {
     // default to newest version
     case Unknown => getBinary(BitcoindVersion.newest)
     case known @ (Experimental | V16 | V17 | V18) =>
@@ -195,6 +195,10 @@ trait BitcoindRpcTestUtil extends BitcoinSLogger {
           fileList
             .filterNot(f => f.toString.endsWith(Experimental.toString.drop(1)))
             .filter(f => f.toString.contains(version))
+
+      if (filtered.isEmpty)
+        throw new RuntimeException(
+          s"bitcoind ${known.toString} is not installed in ${binaryDirectory}. Run `sbt downloadBitcoind`")
 
       // might be multiple versions downloaded for
       // each major version, i.e. 0.16.2 and 0.16.3


### PR DESCRIPTION
In order of commits, this PR:

1) Does a major refactor to the ScriptProgram ADT so that most operations can no longer be performed on PreExecutionScriptPrograms or ExecutedScriptPrograms and can only be performed on ExecutionInProgressScriptPrograms. It also tightens up the input and output types of functions so that not everything is just ScriptProgram => ScriptProgram (this removed a lot of throws!). It replaces methods that are ScriptProgram => ScriptProgram that match on the three types and return the same type as the input into multiple methods with nicer types. Lastly, it refactors ScriptInterpreter.loop to be much nicer and only take in ExecutionInProgressScriptPrograms.
2) Fixes the problem I now had with ScriptInterpreter.loop where it cannot recognize that it is tailrec by moving all calls to loop and loopOrComplete to the bottom of the method.
3) Fix all tests that are now broken by simply turning all PreExecutionScriptPrograms into ExecutionInProgressScriptPrograms.

Formerly the last 3 commits of #771