### PR TITLE
Prevent wallet from initating losing DLCs

### DIFF
--- a/dlc/src/main/scala/org/bitcoins/dlc/DLCClient.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/DLCClient.scala
@@ -216,6 +216,17 @@ case class DLCClient(
   lazy val fundingOutput: TransactionOutput =
     createUnsignedFundingTransaction.outputs.head
 
+  def getPayouts(
+      oracleSig: SchnorrDigitalSignature): (CurrencyUnit, CurrencyUnit) = {
+    sigPubKeys.find(_._2 == oracleSig.sig.toPrivateKey.publicKey) match {
+      case Some((hash, _)) =>
+        (outcomes(hash), remoteOutcomes(hash))
+      case None =>
+        throw new IllegalArgumentException(
+          s"Signature does not correspond to a possible outcome! $oracleSig")
+    }
+  }
+
   def createFundingTransactionSigs(): Future[FundingSignatures] = {
     val fundingTx = createUnsignedFundingTransaction
 
@@ -283,14 +294,7 @@ case class DLCClient(
     * @param sig The oracle's signature for this contract
     */
   def createUnsignedMutualClosePSBT(sig: SchnorrDigitalSignature): PSBT = {
-    val (toLocalPayout, toRemotePayout) =
-      sigPubKeys.find(_._2 == sig.sig.toPrivateKey.publicKey) match {
-        case Some((msg, _)) =>
-          (outcomes(msg), remoteOutcomes(msg))
-        case None =>
-          throw new IllegalArgumentException(
-            s"Signature does not correspond to a possible outcome! $sig")
-      }
+    val (toLocalPayout, toRemotePayout) = getPayouts(sig)
 
     val toLocal =
       TransactionOutput(toLocalPayout,

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/dlc/DLCExecutionTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/dlc/DLCExecutionTest.scala
@@ -217,6 +217,19 @@ class DLCExecutionTest extends BitcoinSDualWalletTest {
     mutualCloseTest(wallets = wallets, asInitiator = false)
   }
 
+  it must "fail to init a losing mutual close" in { wallets =>
+    val dlcA = wallets._1.wallet
+
+    val initMutualCloseF = for {
+      offer <- getInitialOffer(dlcA)
+      (_, sig) = getSigs(offer.contractInfo)
+
+      closeSig <- dlcA.initDLCMutualClose(offer.eventId, sig)
+    } yield closeSig
+
+    recoverToSucceededIf[UnsupportedOperationException](initMutualCloseF)
+  }
+
   it must "do a unilateral close as the initiator" in { wallets =>
     for {
       offer <- getInitialOffer(wallets._1.wallet)
@@ -241,6 +254,19 @@ class DLCExecutionTest extends BitcoinSDualWalletTest {
                                  func = func,
                                  expectedOutputs = 1)
     } yield result
+  }
+
+  it must "fail to do losing unilateral close" in { wallets =>
+    val dlcA = wallets._1.wallet
+
+    val executeDLCForceCloseF = for {
+      offer <- getInitialOffer(dlcA)
+      (_, sig) = getSigs(offer.contractInfo)
+
+      tx <- dlcA.executeDLCForceClose(offer.eventId, sig)
+    } yield tx
+
+    recoverToSucceededIf[UnsupportedOperationException](executeDLCForceCloseF)
   }
 
   it must "do a refund on a dlc as the initiator" in { wallets =>

--- a/wallet/src/main/scala/org/bitcoins/wallet/DLCWallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/DLCWallet.scala
@@ -539,6 +539,11 @@ abstract class DLCWallet extends LockedWallet with UnlockedWalletApi {
                                   fundingInputs,
                                   outcomeSigs)
 
+      (payout, _) = client.getPayouts(oracleSig)
+      _ = if (payout <= 0.satoshis)
+        throw new UnsupportedOperationException(
+          "Cannot execute a losing outcome")
+
       sigMessage <- client.createMutualCloseSig(eventId, oracleSig)
     } yield sigMessage
   }
@@ -558,6 +563,11 @@ abstract class DLCWallet extends LockedWallet with UnlockedWalletApi {
                                       dlcAccept,
                                       fundingInputs,
                                       outcomeSigs)
+
+      (payout, _) = client.getPayouts(oracleSig)
+      _ = if (payout <= 0.satoshis)
+        throw new UnsupportedOperationException(
+          "Cannot execute a losing outcome")
 
       outcome <- client.executeUnilateralDLC(setup, oracleSig)
     } yield {


### PR DESCRIPTION
Should protect users from accidentally screwing themselves.