### PR TITLE
DLC Wallet Multi Nonce support

### DIFF
--- a/app-commons-test/src/test/scala/org/bitcoins/commons/dlc/DLCMessageTest.scala
+++ b/app-commons-test/src/test/scala/org/bitcoins/commons/dlc/DLCMessageTest.scala
@@ -6,7 +6,6 @@ import org.bitcoins.commons.jsonmodels.dlc.{
   DLCPublicKeys,
   DLCTimeouts
 }
-import org.bitcoins.core.config.{MainNet, RegTest, TestNet3}
 import org.bitcoins.core.currency.Satoshis
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.BitcoinAddress
@@ -90,23 +89,6 @@ class DLCMessageTest extends BitcoinSAsyncTest {
         assert(offer.toMessage == offerMsg)
         assert(accept.toMessage == acceptMsg)
         assert(sign.toMessage == signMsg)
-    }
-  }
-
-  it must "be able to go back and forth between Json and deserialized" in {
-    val chainHashes =
-      Vector(MainNet, TestNet3, RegTest).map(_.chainParams.genesisHash)
-
-    forAll(TLVGen.dlcOfferTLVAcceptTLVSignTLV.suchThat(gen =>
-      chainHashes.contains(gen._1.chainHash))) {
-      case (offerTLV, acceptTLV, signTLV) =>
-        val offer = DLCOffer.fromTLV(offerTLV)
-        val accept = DLCAccept.fromTLV(acceptTLV, offer)
-        val sign = DLCSign.fromTLV(signTLV, offer)
-
-        assert(DLCOffer.fromJson(offer.toJson) == offer, offerTLV.hex)
-        assert(DLCAccept.fromJson(accept.toJson) == accept, acceptTLV.hex)
-        assert(DLCSign.fromJson(sign.toJson) == sign, signTLV.hex)
     }
   }
 }

--- a/app-commons-test/src/test/scala/org/bitcoins/commons/dlc/DLCStatusTest.scala
+++ b/app-commons-test/src/test/scala/org/bitcoins/commons/dlc/DLCStatusTest.scala
@@ -1,0 +1,192 @@
+package org.bitcoins.commons.dlc
+
+import org.bitcoins.commons.jsonmodels.dlc.DLCMessage._
+import org.bitcoins.commons.jsonmodels.dlc.DLCStatus
+import org.bitcoins.testkit.core.gen.{
+  CryptoGenerators,
+  NumberGenerator,
+  TLVGen,
+  TransactionGenerators
+}
+import org.bitcoins.testkit.util.BitcoinSAsyncTest
+import org.scalacheck.Gen
+
+class DLCStatusTest extends BitcoinSAsyncTest {
+  behavior of "DLCStatus"
+
+  it must "have json symmetry in DLCStatus.Offered" in {
+    forAllParallel(CryptoGenerators.sha256DigestBE,
+                   NumberGenerator.bool,
+                   TLVGen.dlcOfferTLV) {
+      case (paramHash, isInit, offerTLV) =>
+        val offer = DLCOffer.fromTLV(offerTLV)
+
+        val status =
+          DLCStatus.Offered(paramHash, isInitiator = isInit, offer)
+
+        assert(DLCStatus.fromJson(status.toJson) == status)
+    }
+  }
+
+  it must "have json symmetry in DLCStatus.Accepted" in {
+    forAllParallel(CryptoGenerators.sha256DigestBE,
+                   NumberGenerator.bool,
+                   TLVGen.dlcOfferTLVAcceptTLV) {
+      case (paramHash, isInit, (offerTLV, acceptTLV)) =>
+        val offer = DLCOffer.fromTLV(offerTLV)
+        val accept = DLCAccept.fromTLV(acceptTLV, offer)
+
+        val status = DLCStatus.Accepted(paramHash, isInit, offer, accept)
+
+        assert(DLCStatus.fromJson(status.toJson) == status)
+    }
+  }
+
+  it must "have json symmetry in DLCStatus.Signed" in {
+    forAllParallel(CryptoGenerators.sha256DigestBE,
+                   NumberGenerator.bool,
+                   TLVGen.dlcOfferTLVAcceptTLVSignTLV) {
+      case (paramHash, isInit, (offerTLV, acceptTLV, signTLV)) =>
+        val offer = DLCOffer.fromTLV(offerTLV)
+        val accept = DLCAccept.fromTLV(acceptTLV, offer)
+        val sign = DLCSign.fromTLV(signTLV, offer)
+
+        val status = DLCStatus.Signed(paramHash, isInit, offer, accept, sign)
+
+        assert(DLCStatus.fromJson(status.toJson) == status)
+    }
+  }
+
+  it must "have json symmetry in DLCStatus.Broadcasted" in {
+    forAllParallel(CryptoGenerators.sha256DigestBE,
+                   NumberGenerator.bool,
+                   TLVGen.dlcOfferTLVAcceptTLVSignTLV,
+                   TransactionGenerators.transaction) {
+      case (paramHash, isInit, (offerTLV, acceptTLV, signTLV), fundingTx) =>
+        val offer = DLCOffer.fromTLV(offerTLV)
+        val accept = DLCAccept.fromTLV(acceptTLV, offer)
+        val sign = DLCSign.fromTLV(signTLV, offer)
+
+        val status =
+          DLCStatus.Broadcasted(paramHash,
+                                isInit,
+                                offer,
+                                accept,
+                                sign,
+                                fundingTx)
+
+        assert(DLCStatus.fromJson(status.toJson) == status)
+    }
+  }
+
+  it must "have json symmetry in DLCStatus.Confirmed" in {
+    forAllParallel(CryptoGenerators.sha256DigestBE,
+                   NumberGenerator.bool,
+                   TLVGen.dlcOfferTLVAcceptTLVSignTLV,
+                   TransactionGenerators.transaction) {
+      case (paramHash, isInit, (offerTLV, acceptTLV, signTLV), fundingTx) =>
+        val offer = DLCOffer.fromTLV(offerTLV)
+        val accept = DLCAccept.fromTLV(acceptTLV, offer)
+        val sign = DLCSign.fromTLV(signTLV, offer)
+
+        val status =
+          DLCStatus.Confirmed(paramHash, isInit, offer, accept, sign, fundingTx)
+
+        assert(DLCStatus.fromJson(status.toJson) == status)
+    }
+  }
+
+  it must "have json symmetry in DLCStatus.Claimed" in {
+    forAllParallel(
+      CryptoGenerators.sha256DigestBE,
+      NumberGenerator.bool,
+      TLVGen.dlcOfferTLVAcceptTLVSignTLV,
+      TransactionGenerators.transaction,
+      TransactionGenerators.transaction,
+      Gen.listOf(CryptoGenerators.schnorrDigitalSignature)
+    ) {
+      case (paramHash,
+            isInit,
+            (offerTLV, acceptTLV, signTLV),
+            fundingTx,
+            closingTx,
+            sigs) =>
+        val offer = DLCOffer.fromTLV(offerTLV)
+        val accept = DLCAccept.fromTLV(acceptTLV, offer)
+        val sign = DLCSign.fromTLV(signTLV, offer)
+
+        val status =
+          DLCStatus.Claimed(paramHash,
+                            isInit,
+                            offer,
+                            accept,
+                            sign,
+                            fundingTx,
+                            sigs.toVector,
+                            closingTx)
+
+        assert(DLCStatus.fromJson(status.toJson) == status)
+    }
+  }
+
+  // FIXME can't calculate oracle sig and outcome because of randomized messages and txs
+  it must "have json symmetry in DLCStatus.RemoteClaimed" ignore {
+    forAllParallel(
+      CryptoGenerators.sha256DigestBE,
+      NumberGenerator.bool,
+      TLVGen.dlcOfferTLVAcceptTLVSignTLV,
+      TransactionGenerators.transaction,
+      TransactionGenerators.transaction
+    ) {
+      case (paramHash,
+            isInit,
+            (offerTLV, acceptTLV, signTLV),
+            fundingTx,
+            closingTx) =>
+        val offer = DLCOffer.fromTLV(offerTLV)
+        val accept = DLCAccept.fromTLV(acceptTLV, offer)
+        val sign = DLCSign.fromTLV(signTLV, offer)
+
+        val status =
+          DLCStatus.RemoteClaimed(paramHash,
+                                  isInit,
+                                  offer,
+                                  accept,
+                                  sign,
+                                  fundingTx,
+                                  closingTx)
+
+        assert(DLCStatus.fromJson(status.toJson) == status)
+    }
+  }
+
+  it must "have json symmetry in DLCStatus.Refunded" in {
+    forAllParallel(
+      CryptoGenerators.sha256DigestBE,
+      NumberGenerator.bool,
+      TLVGen.dlcOfferTLVAcceptTLVSignTLV,
+      TransactionGenerators.transaction,
+      TransactionGenerators.transaction
+    ) {
+      case (paramHash,
+            isInit,
+            (offerTLV, acceptTLV, signTLV),
+            fundingTx,
+            closingTx) =>
+        val offer = DLCOffer.fromTLV(offerTLV)
+        val accept = DLCAccept.fromTLV(acceptTLV, offer)
+        val sign = DLCSign.fromTLV(signTLV, offer)
+
+        val status =
+          DLCStatus.Refunded(paramHash,
+                             isInit,
+                             offer,
+                             accept,
+                             sign,
+                             fundingTx,
+                             closingTx)
+
+        assert(DLCStatus.fromJson(status.toJson) == status)
+    }
+  }
+}

--- a/app-commons-test/src/test/scala/org/bitcoins/commons/dlc/SerializedDLCStatusTest.scala
+++ b/app-commons-test/src/test/scala/org/bitcoins/commons/dlc/SerializedDLCStatusTest.scala
@@ -1,0 +1,264 @@
+package org.bitcoins.commons.dlc
+
+import org.bitcoins.commons.jsonmodels.dlc.DLCMessage._
+import org.bitcoins.commons.jsonmodels.dlc.{DLCState, SerializedDLCStatus}
+import org.bitcoins.testkit.core.gen.{CryptoGenerators, NumberGenerator, TLVGen}
+import org.bitcoins.testkit.util.BitcoinSAsyncTest
+import org.scalacheck.Gen
+
+class SerializedDLCStatusTest extends BitcoinSAsyncTest {
+  behavior of "SerializedDLCStatus"
+
+  it must "have json symmetry in SerializedDLCStatus.SerializedOffered" in {
+    forAllParallel(NumberGenerator.bool, TLVGen.dlcOfferTLV) {
+      case (isInit, offerTLV) =>
+        val offer = DLCOffer.fromTLV(offerTLV)
+
+        val totalCollateral = offer.contractInfo.max
+
+        val status =
+          SerializedDLCStatus.SerializedOffered(offer.paramHash,
+                                                isInit,
+                                                offer.tempContractId,
+                                                offer.oracleInfo,
+                                                offer.contractInfo,
+                                                offer.timeouts,
+                                                offer.feeRate,
+                                                totalCollateral,
+                                                offer.totalCollateral)
+
+        assert(status.state == DLCState.Offered)
+        assert(SerializedDLCStatus.fromJson(status.toJson) == status)
+    }
+  }
+
+  it must "have json symmetry in SerializedDLCStatus.SerializedAccepted" in {
+    forAllParallel(NumberGenerator.bool,
+                   TLVGen.dlcOfferTLV,
+                   NumberGenerator.bytevector) {
+      case (isInit, offerTLV, contractId) =>
+        val offer = DLCOffer.fromTLV(offerTLV)
+
+        val totalCollateral = offer.contractInfo.max
+
+        val status =
+          SerializedDLCStatus.SerializedAccepted(
+            offer.paramHash,
+            isInit,
+            offer.tempContractId,
+            contractId,
+            offer.oracleInfo,
+            offer.contractInfo,
+            offer.timeouts,
+            offer.feeRate,
+            totalCollateral,
+            offer.totalCollateral
+          )
+
+        assert(status.state == DLCState.Accepted)
+        assert(SerializedDLCStatus.fromJson(status.toJson) == status)
+    }
+  }
+
+  it must "have json symmetry in SerializedDLCStatus.SerializedSigned" in {
+    forAllParallel(NumberGenerator.bool,
+                   TLVGen.dlcOfferTLV,
+                   NumberGenerator.bytevector) {
+      case (isInit, offerTLV, contractId) =>
+        val offer = DLCOffer.fromTLV(offerTLV)
+
+        val totalCollateral = offer.contractInfo.max
+
+        val status =
+          SerializedDLCStatus.SerializedSigned(
+            offer.paramHash,
+            isInit,
+            offer.tempContractId,
+            contractId,
+            offer.oracleInfo,
+            offer.contractInfo,
+            offer.timeouts,
+            offer.feeRate,
+            totalCollateral,
+            offer.totalCollateral
+          )
+
+        assert(status.state == DLCState.Signed)
+        assert(SerializedDLCStatus.fromJson(status.toJson) == status)
+    }
+  }
+
+  it must "have json symmetry in SerializedDLCStatus.SerializedBroadcasted" in {
+    forAllParallel(NumberGenerator.bool,
+                   TLVGen.dlcOfferTLV,
+                   NumberGenerator.bytevector,
+                   CryptoGenerators.doubleSha256DigestBE) {
+      case (isInit, offerTLV, contractId, fundingTxId) =>
+        val offer = DLCOffer.fromTLV(offerTLV)
+
+        val totalCollateral = offer.contractInfo.max
+
+        val status =
+          SerializedDLCStatus.SerializedBroadcasted(
+            offer.paramHash,
+            isInit,
+            offer.tempContractId,
+            contractId,
+            offer.oracleInfo,
+            offer.contractInfo,
+            offer.timeouts,
+            offer.feeRate,
+            totalCollateral,
+            offer.totalCollateral,
+            fundingTxId
+          )
+
+        assert(status.state == DLCState.Broadcasted)
+        assert(SerializedDLCStatus.fromJson(status.toJson) == status)
+    }
+  }
+
+  it must "have json symmetry in SerializedDLCStatus.SerializedConfirmed" in {
+    forAllParallel(NumberGenerator.bool,
+                   TLVGen.dlcOfferTLV,
+                   NumberGenerator.bytevector,
+                   CryptoGenerators.doubleSha256DigestBE) {
+      case (isInit, offerTLV, contractId, fundingTxId) =>
+        val offer = DLCOffer.fromTLV(offerTLV)
+
+        val totalCollateral = offer.contractInfo.max
+
+        val status =
+          SerializedDLCStatus.SerializedConfirmed(
+            offer.paramHash,
+            isInit,
+            offer.tempContractId,
+            contractId,
+            offer.oracleInfo,
+            offer.contractInfo,
+            offer.timeouts,
+            offer.feeRate,
+            totalCollateral,
+            offer.totalCollateral,
+            fundingTxId
+          )
+
+        assert(status.state == DLCState.Confirmed)
+        assert(SerializedDLCStatus.fromJson(status.toJson) == status)
+    }
+  }
+
+  it must "have json symmetry in SerializedDLCStatus.SerializedClaimed" in {
+    forAllParallel(
+      NumberGenerator.bool,
+      TLVGen.dlcOfferTLV,
+      NumberGenerator.bytevector,
+      CryptoGenerators.doubleSha256DigestBE,
+      CryptoGenerators.doubleSha256DigestBE,
+      Gen.listOf(CryptoGenerators.schnorrDigitalSignature)
+    ) {
+      case (isInit, offerTLV, contractId, fundingTxId, closingTxId, sigs) =>
+        val offer = DLCOffer.fromTLV(offerTLV)
+
+        val totalCollateral = offer.contractInfo.max
+
+        val rand = Math.random() * offer.contractInfo.allOutcomes.size
+        val outcome = offer.contractInfo.allOutcomes(rand.toInt)
+
+        val status =
+          SerializedDLCStatus.SerializedClaimed(
+            offer.paramHash,
+            isInit,
+            offer.tempContractId,
+            contractId,
+            offer.oracleInfo,
+            offer.contractInfo,
+            offer.timeouts,
+            offer.feeRate,
+            totalCollateral,
+            offer.totalCollateral,
+            fundingTxId,
+            closingTxId,
+            sigs.toVector,
+            outcome
+          )
+
+        assert(status.state == DLCState.Claimed)
+        assert(SerializedDLCStatus.fromJson(status.toJson) == status)
+    }
+  }
+
+  it must "have json symmetry in SerializedDLCStatus.SerializedRemoteClaimed" in {
+    forAllParallel(
+      NumberGenerator.bool,
+      TLVGen.dlcOfferTLV,
+      NumberGenerator.bytevector,
+      CryptoGenerators.doubleSha256DigestBE,
+      CryptoGenerators.doubleSha256DigestBE,
+      CryptoGenerators.schnorrDigitalSignature
+    ) {
+      case (isInit, offerTLV, contractId, fundingTxId, closingTxId, sig) =>
+        val offer = DLCOffer.fromTLV(offerTLV)
+
+        val totalCollateral = offer.contractInfo.max
+
+        val rand = Math.random() * offer.contractInfo.allOutcomes.size
+        val outcome = offer.contractInfo.allOutcomes(rand.toInt)
+
+        val status =
+          SerializedDLCStatus.SerializedRemoteClaimed(
+            offer.paramHash,
+            isInit,
+            offer.tempContractId,
+            contractId,
+            offer.oracleInfo,
+            offer.contractInfo,
+            offer.timeouts,
+            offer.feeRate,
+            totalCollateral,
+            offer.totalCollateral,
+            fundingTxId,
+            closingTxId,
+            sig,
+            outcome
+          )
+
+        assert(status.state == DLCState.RemoteClaimed)
+        assert(SerializedDLCStatus.fromJson(status.toJson) == status)
+    }
+  }
+
+  it must "have json symmetry in SerializedDLCStatus.SerializedRefunded" in {
+    forAllParallel(
+      NumberGenerator.bool,
+      TLVGen.dlcOfferTLV,
+      NumberGenerator.bytevector,
+      CryptoGenerators.doubleSha256DigestBE,
+      CryptoGenerators.doubleSha256DigestBE
+    ) {
+      case (isInit, offerTLV, contractId, fundingTxId, closingTxId) =>
+        val offer = DLCOffer.fromTLV(offerTLV)
+
+        val totalCollateral = offer.contractInfo.max
+
+        val status =
+          SerializedDLCStatus.SerializedRefunded(
+            offer.paramHash,
+            isInit,
+            offer.tempContractId,
+            contractId,
+            offer.oracleInfo,
+            offer.contractInfo,
+            offer.timeouts,
+            offer.feeRate,
+            totalCollateral,
+            offer.totalCollateral,
+            fundingTxId,
+            closingTxId
+          )
+
+        assert(status.state == DLCState.Refunded)
+        assert(SerializedDLCStatus.fromJson(status.toJson) == status)
+    }
+  }
+}

--- a/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/dlc/DLCMessage.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/dlc/DLCMessage.scala
@@ -426,17 +426,6 @@ object DLCMessage {
       outcomeMap(outcome)
     }
 
-    def outcomeFromSignature(
-        sigs: Vector[SchnorrDigitalSignature]): DLCOutcomeType = {
-      val sigPoint = sigs.map(_.sig.getPublicKey).reduce(_.add(_))
-      outcomeMap.find(_._2._1 == sigPoint) match {
-        case Some((outcome, _)) => outcome
-        case None =>
-          throw new IllegalArgumentException(
-            s"Signatures do not correspond to a possible outcome! $sigs")
-      }
-    }
-
     def sigPointForOutcome(outcome: DLCOutcomeType): ECPublicKey = {
       resultOfOutcome(outcome)._1
     }
@@ -447,7 +436,12 @@ object DLCMessage {
     /** Returns the payouts for the signature as (toOffer, toAccept) */
     def getPayouts(
         sigs: Vector[SchnorrDigitalSignature]): (Satoshis, Satoshis) = {
-      val outcome = outcomeFromSignature(sigs)
+      val outcome = findOutcome(sigs) match {
+        case Some(outcome) => outcome
+        case None =>
+          throw new IllegalArgumentException(
+            s"Signatures do not correspond to a possible outcome! $sigs")
+      }
       getPayouts(outcome)
     }
 

--- a/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/dlc/DLCMessage.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/dlc/DLCMessage.scala
@@ -4,27 +4,19 @@ import java.nio.charset.StandardCharsets
 
 import org.bitcoins.core.config.{NetworkParameters, Networks}
 import org.bitcoins.core.currency.Satoshis
-import org.bitcoins.core.number.{UInt16, UInt32}
-import org.bitcoins.core.protocol.script.{ScriptWitnessV0, WitnessScriptPubKey}
 import org.bitcoins.core.protocol.tlv._
-import org.bitcoins.core.protocol.transaction.{Transaction, TransactionOutPoint}
-import org.bitcoins.core.protocol.{BigSizeUInt, BitcoinAddress, BlockTimeStamp}
+import org.bitcoins.core.protocol.transaction.TransactionOutPoint
+import org.bitcoins.core.protocol.{BigSizeUInt, BitcoinAddress}
 import org.bitcoins.core.psbt.InputPSBTRecord.PartialSignature
 import org.bitcoins.core.script.crypto.HashType
-import org.bitcoins.core.serializers.script.RawScriptWitnessParser
 import org.bitcoins.core.util.SeqWrapper
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.crypto._
 import scodec.bits.ByteVector
-import ujson._
 
 import scala.annotation.tailrec
-import scala.collection.mutable
 
-sealed trait DLCMessage {
-  def toJson: Value
-  def toJsonStr: String = toJson.toString()
-}
+sealed trait DLCMessage
 
 object DLCMessage {
 
@@ -35,12 +27,6 @@ object DLCMessage {
     CryptoUtil
       .sha256(oracleInfo.bytes ++ contractInfo.bytes ++ timeouts.bytes)
       .flip
-  }
-
-  private def getValue(key: String)(implicit
-      obj: mutable.LinkedHashMap[String, Value]): Value = {
-    val index = obj.keys.toList.indexOf(key)
-    obj.values(index)
   }
 
   sealed trait OracleInfo extends NetworkElement {
@@ -297,6 +283,7 @@ object DLCMessage {
       totalCollateral: Satoshis)
       extends ContractInfo {
 
+    /** Vector is always the most significant digits */
     lazy val outcomeVec: Vector[(Vector[Int], Satoshis)] =
       CETCalculator.computeCETs(base,
                                 numDigits,
@@ -321,7 +308,7 @@ object DLCMessage {
       }
     }
 
-    override def allOutcomes: Vector[DLCOutcomeType] =
+    override lazy val allOutcomes: Vector[DLCOutcomeType] =
       outcomeVec.map { case (outcome, _) => UnsignedNumericOutcome(outcome) }
 
     override def max: Satoshis = totalCollateral
@@ -533,60 +520,6 @@ object DLCMessage {
     def toMessage: LnMessage[DLCOfferTLV] = {
       LnMessage(this.toTLV)
     }
-
-    override def toJson: Value = {
-      val contractInfosJson =
-        contractInfo match {
-          case SingleNonceContractInfo(outcomeValueMap) =>
-            outcomeValueMap.map(info =>
-              mutable.LinkedHashMap("outcome" -> Str(info._1.outcome),
-                                    "sats" -> Num(info._2.toLong.toDouble)))
-          case MultiNonceContractInfo(_, _, _, _) => ???
-        }
-
-      val fundingInputsJson =
-        fundingInputs.map { input =>
-          val obj = mutable.LinkedHashMap(
-            "prevTx" -> Str(input.prevTx.hex),
-            "prevTxVout" -> Num(input.prevTxVout.toLong.toDouble),
-            "sequence" -> Num(input.sequence.toLong.toDouble),
-            "maxWitnessLength" -> Num(input.maxWitnessLen.toLong.toDouble)
-          )
-
-          input.redeemScriptOpt.foreach { redeemScript =>
-            obj.+=("redeemScript" -> Str(redeemScript.hex))
-          }
-
-          obj
-        }
-
-      val timeoutsJson =
-        mutable.LinkedHashMap(
-          "contractMaturity" -> Num(
-            timeouts.contractMaturity.toUInt32.toLong.toDouble),
-          "contractTimeout" -> Num(
-            timeouts.contractTimeout.toUInt32.toLong.toDouble)
-        )
-
-      val pubKeysJson =
-        mutable.LinkedHashMap(
-          "fundingKey" -> Str(pubKeys.fundingKey.hex),
-          "payoutAddress" -> Str(pubKeys.payoutAddress.value)
-        )
-
-      Obj(
-        mutable.LinkedHashMap[String, Value](
-          "contractInfo" -> contractInfosJson,
-          "oracleInfo" -> Str(oracleInfo.hex),
-          "pubKeys" -> pubKeysJson,
-          "totalCollateral" -> Num(totalCollateral.toLong.toDouble),
-          "fundingInputs" -> fundingInputsJson,
-          "changeAddress" -> Str(changeAddress.value),
-          "feeRate" -> Num(feeRate.toLong.toDouble),
-          "timeouts" -> timeoutsJson
-        )
-      )
-    }
   }
 
   object DLCOffer {
@@ -616,119 +549,6 @@ object DLCMessage {
 
     def fromMessage(offer: LnMessage[DLCOfferTLV]): DLCOffer = {
       fromTLV(offer.tlv)
-    }
-
-    def fromJson(js: Value): DLCOffer = {
-      val vec = js.obj.toVector
-
-      val contractInfoMap =
-        vec
-          .find(_._1 == "contractInfo")
-          .map {
-            case (_, value) =>
-              value.arr.map { subVal =>
-                implicit val obj: mutable.LinkedHashMap[String, Value] =
-                  subVal.obj
-
-                val outcome =
-                  getValue("outcome")
-                val sats = getValue("sats")
-
-                (EnumOutcome(outcome.str), Satoshis(sats.num.toLong))
-              }
-          }
-          .get
-          .toVector
-
-      val fundingInputs =
-        vec
-          .find(_._1 == "fundingInputs")
-          .map {
-            case (_, value) =>
-              value.arr.map { subVal =>
-                implicit val obj: mutable.LinkedHashMap[String, Value] =
-                  subVal.obj
-
-                val prevTx = Transaction(getValue("prevTx").str)
-                val prevTxVout = UInt32(getValue("prevTxVout").num.toInt)
-                val sequence = UInt32(getValue("sequence").num.toLong)
-                val maxWitnessLen =
-                  UInt16(getValue("maxWitnessLength").num.toInt)
-                val redeemScriptOpt = obj.find(_._1 == "redeemScript").map {
-                  case (_, redeemScript) =>
-                    WitnessScriptPubKey(redeemScript.str)
-                }
-
-                DLCFundingInput(prevTx,
-                                prevTxVout,
-                                sequence,
-                                maxWitnessLen,
-                                redeemScriptOpt)
-              }
-          }
-          .get
-          .toVector
-
-      val oracleInfo =
-        vec.find(_._1 == "oracleInfo").map(obj => OracleInfo(obj._2.str)).get
-
-      val pubKeys =
-        vec
-          .find(_._1 == "pubKeys")
-          .map {
-            case (_, value) =>
-              implicit val obj: mutable.LinkedHashMap[String, Value] = value.obj
-
-              val fundingKey = getValue("fundingKey")
-              val payoutAddress = getValue("payoutAddress")
-
-              DLCPublicKeys(
-                ECPublicKey(fundingKey.str),
-                BitcoinAddress(payoutAddress.str)
-              )
-          }
-          .get
-
-      val totalCollateral = vec
-        .find(_._1 == "totalCollateral")
-        .map(obj => Satoshis(obj._2.num.toLong))
-        .get
-      val changeAddress =
-        vec
-          .find(_._1 == "changeAddress")
-          .map(obj => BitcoinAddress.fromString(obj._2.str))
-          .get
-      val feeRate =
-        vec
-          .find(_._1 == "feeRate")
-          .map(obj => SatoshisPerVirtualByte(Satoshis(obj._2.num.toLong)))
-          .get
-
-      val timeouts =
-        vec
-          .find(_._1 == "timeouts")
-          .map {
-            case (_, value) =>
-              implicit val obj: mutable.LinkedHashMap[String, Value] = value.obj
-              val contractMaturity = getValue("contractMaturity")
-              val contractTimeout = getValue("contractTimeout")
-
-              DLCTimeouts(
-                BlockTimeStamp(UInt32(contractMaturity.num.toLong)),
-                BlockTimeStamp(UInt32(contractTimeout.num.toLong))
-              )
-          }
-          .get
-
-      DLCOffer(OracleAndContractInfo(oracleInfo,
-                                     SingleNonceContractInfo(contractInfoMap)),
-               pubKeys,
-               totalCollateral,
-               fundingInputs,
-               changeAddress,
-               feeRate,
-               timeouts)
-
     }
   }
 
@@ -776,54 +596,6 @@ object DLCMessage {
       LnMessage(this.toTLV)
     }
 
-    def toJson: Value = {
-      val fundingInputsJson =
-        fundingInputs.map { input =>
-          val obj = mutable.LinkedHashMap(
-            "prevTx" -> Str(input.prevTx.hex),
-            "prevTxVout" -> Num(input.prevTxVout.toInt),
-            "sequence" -> Num(input.sequence.toLong.toDouble),
-            "maxWitnessLength" -> Num(input.maxWitnessLen.toInt)
-          )
-
-          input.redeemScriptOpt.foreach { redeemScript =>
-            obj.+=("redeemScript" -> Str(redeemScript.hex))
-          }
-
-          obj
-        }
-
-      val outcomeSigsJson =
-        cetSigs.outcomeSigs.map {
-          case (outcome, sig) =>
-            val str = outcome match {
-              case EnumOutcome(outcome)      => outcome
-              case UnsignedNumericOutcome(_) => ???
-            }
-            mutable.LinkedHashMap(str -> Str(sig.hex))
-        }
-
-      val cetSigsJson =
-        mutable.LinkedHashMap("outcomeSigs" -> Value(outcomeSigsJson),
-                              "refundSig" -> Str(cetSigs.refundSig.hex))
-      val pubKeysJson =
-        mutable.LinkedHashMap(
-          "fundingKey" -> Str(pubKeys.fundingKey.hex),
-          "payoutAddress" -> Str(pubKeys.payoutAddress.value)
-        )
-
-      Obj(
-        mutable.LinkedHashMap[String, Value](
-          "totalCollateral" -> Num(totalCollateral.toLong.toDouble),
-          "pubKeys" -> pubKeysJson,
-          "fundingInputs" -> fundingInputsJson,
-          "changeAddress" -> Str(changeAddress.value),
-          "cetSigs" -> cetSigsJson,
-          "tempContractId" -> Str(tempContractId.hex)
-        )
-      )
-    }
-
     def withoutSigs: DLCAcceptWithoutSigs = {
       DLCAcceptWithoutSigs(totalCollateral,
                            pubKeys,
@@ -864,116 +636,26 @@ object DLCMessage {
       )
     }
 
-    def fromTLV(accept: DLCAcceptTLV, offer: DLCOffer): DLCAccept = {
-      offer.contractInfo match {
+    def fromTLV(
+        accept: DLCAcceptTLV,
+        network: NetworkParameters,
+        contractInfo: ContractInfo): DLCAccept = {
+      contractInfo match {
         case info: SingleNonceContractInfo =>
-          fromTLV(accept, offer.changeAddress.networkParameters, info.keys)
-        case MultiNonceContractInfo(_, _, _, _) => ???
+          fromTLV(accept, network, info.keys)
+        case multi: MultiNonceContractInfo =>
+          fromTLV(accept, network, multi.allOutcomes)
       }
+    }
+
+    def fromTLV(accept: DLCAcceptTLV, offer: DLCOffer): DLCAccept = {
+      fromTLV(accept, offer.changeAddress.networkParameters, offer.contractInfo)
     }
 
     def fromMessage(
         accept: LnMessage[DLCAcceptTLV],
         offer: DLCOffer): DLCAccept = {
       fromTLV(accept.tlv, offer)
-    }
-
-    def fromJson(js: Value): DLCAccept = {
-      val vec = js.obj.toVector
-
-      val totalCollateral = vec
-        .find(_._1 == "totalCollateral")
-        .map(obj => Satoshis(obj._2.num.toLong))
-        .get
-      val changeAddress =
-        vec
-          .find(_._1 == "changeAddress")
-          .map(obj => BitcoinAddress.fromString(obj._2.str))
-          .get
-
-      val pubKeys =
-        vec
-          .find(_._1 == "pubKeys")
-          .map {
-            case (_, value) =>
-              implicit val obj: mutable.LinkedHashMap[String, Value] = value.obj
-
-              val fundingKey =
-                getValue("fundingKey")
-              val payoutAddress =
-                getValue("payoutAddress")
-
-              DLCPublicKeys(
-                ECPublicKey(fundingKey.str),
-                BitcoinAddress(payoutAddress.str)
-              )
-          }
-          .get
-
-      val fundingInputs =
-        vec
-          .find(_._1 == "fundingInputs")
-          .map {
-            case (_, value) =>
-              value.arr.map { subVal =>
-                implicit val obj: mutable.LinkedHashMap[String, Value] =
-                  subVal.obj
-
-                val prevTx = Transaction(getValue("prevTx").str)
-                val prevTxVout = UInt32(getValue("prevTxVout").num.toInt)
-                val sequence = UInt32(getValue("sequence").num.toLong)
-                val maxWitnessLen =
-                  UInt16(getValue("maxWitnessLength").num.toInt)
-                val redeemScriptOpt = obj.find(_._1 == "redeemScript").map {
-                  case (_, redeemScript) =>
-                    WitnessScriptPubKey(redeemScript.str)
-                }
-
-                DLCFundingInput(prevTx,
-                                prevTxVout,
-                                sequence,
-                                maxWitnessLen,
-                                redeemScriptOpt)
-              }
-          }
-          .get
-          .toVector
-
-      val cetSigs =
-        vec
-          .find(_._1 == "cetSigs")
-          .map {
-            case (_, value) =>
-              implicit val obj: mutable.LinkedHashMap[String, Value] = value.obj
-
-              val outcomeSigsMap = getValue("outcomeSigs")
-              val outcomeSigs = outcomeSigsMap.arr.map { v =>
-                val (key, value) = v.obj.head
-                val sig = ECAdaptorSignature(value.str)
-                (EnumOutcome(key), sig)
-              }
-
-              val refundSig = getValue("refundSig")
-
-              CETSignatures(
-                outcomeSigs.toVector,
-                PartialSignature(refundSig.str)
-              )
-          }
-          .get
-
-      val tempContractId =
-        vec
-          .find(_._1 == "tempContractId")
-          .map(obj => Sha256Digest(obj._2.str))
-          .get
-
-      DLCAccept(totalCollateral,
-                pubKeys,
-                fundingInputs,
-                changeAddress,
-                cetSigs,
-                tempContractId)
     }
   }
 
@@ -995,41 +677,6 @@ object DLCMessage {
 
     def toMessage: LnMessage[DLCSignTLV] = {
       LnMessage(this.toTLV)
-    }
-
-    def toJson: Value = {
-
-      val fundingSigsMap = fundingSigs.map {
-        case (outPoint, scriptWitness) =>
-          (outPoint.hex, Str(scriptWitness.hex))
-      }
-
-      val fundingSigsJson = fundingSigsMap
-        .foldLeft(mutable.LinkedHashMap.newBuilder[String, Value])(
-          (builder, element) => builder += element)
-        .result()
-
-      val outcomeSigsJson =
-        cetSigs.outcomeSigs.map {
-          case (outcome, sig) =>
-            val str = outcome match {
-              case EnumOutcome(outcome)      => outcome
-              case UnsignedNumericOutcome(_) => ???
-            }
-            mutable.LinkedHashMap(str -> Str(sig.hex))
-        }
-
-      val cetSigsJson =
-        mutable.LinkedHashMap("outcomeSigs" -> Value(outcomeSigsJson),
-                              "refundSig" -> Str(cetSigs.refundSig.hex))
-
-      Obj(
-        mutable.LinkedHashMap[String, Value](
-          "cetSigs" -> cetSigsJson,
-          "fundingSigs" -> fundingSigsJson,
-          "contractId" -> Str(contractId.toHex)
-        )
-      )
     }
   }
 
@@ -1070,67 +717,16 @@ object DLCMessage {
                   offer.pubKeys.fundingKey,
                   info.keys,
                   offer.fundingInputs.map(_.outPoint))
-        case MultiNonceContractInfo(_, _, _, _) => ???
+        case multi: MultiNonceContractInfo =>
+          fromTLV(sign,
+                  offer.pubKeys.fundingKey,
+                  multi.allOutcomes,
+                  offer.fundingInputs.map(_.outPoint))
       }
     }
 
     def fromMessage(sign: LnMessage[DLCSignTLV], offer: DLCOffer): DLCSign = {
       fromTLV(sign.tlv, offer)
-    }
-
-    def fromJson(js: Value): DLCSign = {
-      val vec = js.obj.toVector
-
-      val cetSigs =
-        vec
-          .find(_._1 == "cetSigs")
-          .map {
-            case (_, value) =>
-              implicit val obj: mutable.LinkedHashMap[String, Value] = value.obj
-
-              val outcomeSigsMap = getValue("outcomeSigs")
-              val outcomeSigs = outcomeSigsMap.arr.map { item =>
-                val (key, value) = item.obj.head
-                val sig = ECAdaptorSignature(value.str)
-                (EnumOutcome(key), sig)
-              }
-
-              val refundSig = getValue("refundSig")
-
-              CETSignatures(
-                outcomeSigs.toVector,
-                PartialSignature(refundSig.str)
-              )
-          }
-          .get
-
-      val fundingSigs =
-        vec
-          .find(_._1 == "fundingSigs")
-          .map {
-            case (_, value) =>
-              if (value.obj.isEmpty) {
-                throw new RuntimeException(
-                  s"DLC Sign cannot have empty fundingSigs, got $js")
-              } else {
-                value.obj.toVector.map {
-                  case (outPoint, scriptWitness) =>
-                    (TransactionOutPoint(outPoint),
-                     RawScriptWitnessParser
-                       .read(scriptWitness.str)
-                       .asInstanceOf[ScriptWitnessV0])
-                }
-              }
-          }
-          .get
-
-      val contractId =
-        vec
-          .find(_._1 == "contractId")
-          .map(obj => ByteVector.fromValidHex(obj._2.str))
-          .get
-
-      DLCSign(cetSigs, FundingSignatures(fundingSigs), contractId)
     }
   }
 

--- a/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/dlc/DLCStatus.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/dlc/DLCStatus.scala
@@ -65,7 +65,7 @@ object DLCStatus {
         "state" -> Str(state.toString),
         "paramHash" -> Str(paramHash.hex),
         "isInitiator" -> Bool(isInitiator),
-        "offer" -> Str(LnMessage(offer.toTLV).hex)
+        "offer" -> Str(offer.toMessage.hex)
       )
   }
 
@@ -89,8 +89,8 @@ object DLCStatus {
         "state" -> Str(state.toString),
         "paramHash" -> Str(paramHash.hex),
         "isInitiator" -> Bool(isInitiator),
-        "offer" -> Str(LnMessage(offer.toTLV).hex),
-        "accept" -> Str(LnMessage(accept.toTLV).hex)
+        "offer" -> Str(offer.toMessage.hex),
+        "accept" -> Str(accept.toMessage.hex)
       )
   }
 
@@ -121,9 +121,9 @@ object DLCStatus {
         "state" -> Str(state.toString),
         "paramHash" -> Str(paramHash.hex),
         "isInitiator" -> Bool(isInitiator),
-        "offer" -> Str(LnMessage(offer.toTLV).hex),
-        "accept" -> Str(LnMessage(accept.toTLV).hex),
-        "sign" -> Str(LnMessage(sign.toTLV).hex)
+        "offer" -> Str(offer.toMessage.hex),
+        "accept" -> Str(accept.toMessage.hex),
+        "sign" -> Str(sign.toMessage.hex)
       )
   }
 
@@ -150,9 +150,9 @@ object DLCStatus {
         "state" -> Str(state.toString),
         "paramHash" -> Str(paramHash.hex),
         "isInitiator" -> Bool(isInitiator),
-        "offer" -> Str(LnMessage(offer.toTLV).hex),
-        "accept" -> Str(LnMessage(accept.toTLV).hex),
-        "sign" -> Str(LnMessage(sign.toTLV).hex),
+        "offer" -> Str(offer.toMessage.hex),
+        "accept" -> Str(accept.toMessage.hex),
+        "sign" -> Str(sign.toMessage.hex),
         "fundingTxId" -> Str(fundingTx.txIdBE.hex),
         "fundingTx" -> Str(fundingTx.hex)
       )
@@ -194,9 +194,9 @@ object DLCStatus {
         "state" -> Str(state.toString),
         "paramHash" -> Str(paramHash.hex),
         "isInitiator" -> Bool(isInitiator),
-        "offer" -> Str(LnMessage(offer.toTLV).hex),
-        "accept" -> Str(LnMessage(accept.toTLV).hex),
-        "sign" -> Str(LnMessage(sign.toTLV).hex),
+        "offer" -> Str(offer.toMessage.hex),
+        "accept" -> Str(accept.toMessage.hex),
+        "sign" -> Str(sign.toMessage.hex),
         "fundingTxId" -> Str(fundingTx.txIdBE.hex),
         "fundingTx" -> Str(fundingTx.hex)
       )
@@ -226,20 +226,29 @@ object DLCStatus {
       }
     }
 
-    override lazy val toJson: Value =
+    override lazy val toJson: Value = {
+      val outcomeJs = outcome match {
+        case EnumOutcome(outcome) =>
+          Str(outcome)
+        case UnsignedNumericOutcome(digits) =>
+          Arr.from(digits.map(num => Num(num)))
+      }
+
       Obj(
         "state" -> Str(state.toString),
         "paramHash" -> Str(paramHash.hex),
         "isInitiator" -> Bool(isInitiator),
-        "offer" -> Str(LnMessage(offer.toTLV).hex),
-        "accept" -> Str(LnMessage(accept.toTLV).hex),
-        "sign" -> Str(LnMessage(sign.toTLV).hex),
+        "offer" -> Str(offer.toMessage.hex),
+        "accept" -> Str(accept.toMessage.hex),
+        "sign" -> Str(sign.toMessage.hex),
         "fundingTxId" -> Str(fundingTx.txIdBE.hex),
         "fundingTx" -> Str(fundingTx.hex),
         "oracleSigs" -> oracleSigs.map(sig => Str(sig.hex)),
+        "outcome" -> outcomeJs,
         "cetTxId" -> Str(cet.txIdBE.hex),
         "cet" -> Str(cet.hex)
       )
+    }
 
     override lazy val closingTx: Transaction = cet
   }
@@ -388,9 +397,9 @@ object DLCStatus {
         "state" -> Str(state.toString),
         "paramHash" -> Str(paramHash.hex),
         "isInitiator" -> Bool(isInitiator),
-        "offer" -> Str(LnMessage(offer.toTLV).hex),
-        "accept" -> Str(LnMessage(accept.toTLV).hex),
-        "sign" -> Str(LnMessage(sign.toTLV).hex),
+        "offer" -> Str(offer.toMessage.hex),
+        "accept" -> Str(accept.toMessage.hex),
+        "sign" -> Str(sign.toMessage.hex),
         "fundingTxId" -> Str(fundingTx.txIdBE.hex),
         "fundingTx" -> Str(fundingTx.hex),
         "oracleSig" -> Str(oracleSig.hex),
@@ -422,9 +431,9 @@ object DLCStatus {
         "state" -> Str(state.toString),
         "paramHash" -> Str(paramHash.hex),
         "isInitiator" -> Bool(isInitiator),
-        "offer" -> Str(LnMessage(offer.toTLV).hex),
-        "accept" -> Str(LnMessage(accept.toTLV).hex),
-        "sign" -> Str(LnMessage(sign.toTLV).hex),
+        "offer" -> Str(offer.toMessage.hex),
+        "accept" -> Str(accept.toMessage.hex),
+        "sign" -> Str(sign.toMessage.hex),
         "fundingTxId" -> Str(fundingTx.txIdBE.hex),
         "fundingTx" -> Str(fundingTx.hex),
         "refundTxId" -> Str(refundTx.txIdBE.hex),
@@ -440,14 +449,14 @@ object DLCStatus {
     val state = DLCState.fromString(obj("state").str)
     val paramHash = Sha256DigestBE(obj("paramHash").str)
     val isInitiator = obj("isInitiator").bool
-    val offer = DLCOffer.fromTLV(
-      LnMessageFactory(DLCOfferTLV).fromHex(obj("offer").str).tlv)
+    val offer = DLCOffer.fromMessage(
+      LnMessageFactory(DLCOfferTLV).fromHex(obj("offer").str))
 
-    lazy val accept = DLCAccept.fromTLV(
-      LnMessageFactory(DLCAcceptTLV).fromHex(obj("accept").str).tlv,
+    lazy val accept = DLCAccept.fromMessage(
+      LnMessageFactory(DLCAcceptTLV).fromHex(obj("accept").str),
       offer)
-    lazy val sign = DLCSign.fromTLV(
-      LnMessageFactory(DLCSignTLV).fromHex(obj("sign").str).tlv,
+    lazy val sign = DLCSign.fromMessage(
+      LnMessageFactory(DLCSignTLV).fromHex(obj("sign").str),
       offer)
     lazy val fundingTx = Transaction(obj("fundingTx").str)
     lazy val cet = Transaction(obj("cet").str)

--- a/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/dlc/DLCStatus.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/dlc/DLCStatus.scala
@@ -373,7 +373,15 @@ object DLCStatus {
       }
     }
 
-    override lazy val toJson: Value =
+    override lazy val toJson: Value = {
+
+      val outcomeJs = outcome match {
+        case EnumOutcome(outcome) =>
+          Str(outcome)
+        case UnsignedNumericOutcome(digits) =>
+          Arr.from(digits.map(num => Num(num)))
+      }
+
       Obj(
         "state" -> Str(state.toString),
         "paramHash" -> Str(paramHash.hex),
@@ -384,9 +392,11 @@ object DLCStatus {
         "fundingTxId" -> Str(fundingTx.txIdBE.hex),
         "fundingTx" -> Str(fundingTx.hex),
         "oracleSig" -> Str(oracleSig.hex),
+        "outcome" -> outcomeJs,
         "cetTxId" -> Str(cet.txIdBE.hex),
         "cet" -> Str(cet.hex)
       )
+    }
 
     override def closingTx: Transaction = cet
   }

--- a/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/dlc/DLCStatus.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/dlc/DLCStatus.scala
@@ -3,14 +3,7 @@ package org.bitcoins.commons.jsonmodels.dlc
 import org.bitcoins.commons.jsonmodels.dlc.DLCMessage._
 import org.bitcoins.core.policy.Policy
 import org.bitcoins.core.protocol.script.P2WSHWitnessV0
-import org.bitcoins.core.protocol.tlv.{
-  DLCAcceptTLV,
-  DLCOfferTLV,
-  DLCOutcomeType,
-  DLCSignTLV,
-  EnumOutcome,
-  UnsignedNumericOutcome
-}
+import org.bitcoins.core.protocol.tlv._
 import org.bitcoins.core.protocol.transaction.{Transaction, WitnessTransaction}
 import org.bitcoins.crypto._
 import scodec.bits.ByteVector
@@ -72,7 +65,7 @@ object DLCStatus {
         "state" -> Str(state.toString),
         "paramHash" -> Str(paramHash.hex),
         "isInitiator" -> Bool(isInitiator),
-        "offer" -> Str(offer.toTLV.hex)
+        "offer" -> Str(LnMessage(offer.toTLV).hex)
       )
   }
 
@@ -96,8 +89,8 @@ object DLCStatus {
         "state" -> Str(state.toString),
         "paramHash" -> Str(paramHash.hex),
         "isInitiator" -> Bool(isInitiator),
-        "offer" -> Str(offer.toTLV.hex),
-        "accept" -> Str(accept.toTLV.hex)
+        "offer" -> Str(LnMessage(offer.toTLV).hex),
+        "accept" -> Str(LnMessage(accept.toTLV).hex)
       )
   }
 
@@ -128,9 +121,9 @@ object DLCStatus {
         "state" -> Str(state.toString),
         "paramHash" -> Str(paramHash.hex),
         "isInitiator" -> Bool(isInitiator),
-        "offer" -> Str(offer.toTLV.hex),
-        "accept" -> Str(accept.toTLV.hex),
-        "sign" -> Str(sign.toTLV.hex)
+        "offer" -> Str(LnMessage(offer.toTLV).hex),
+        "accept" -> Str(LnMessage(accept.toTLV).hex),
+        "sign" -> Str(LnMessage(sign.toTLV).hex)
       )
   }
 
@@ -157,9 +150,9 @@ object DLCStatus {
         "state" -> Str(state.toString),
         "paramHash" -> Str(paramHash.hex),
         "isInitiator" -> Bool(isInitiator),
-        "offer" -> Str(offer.toTLV.hex),
-        "accept" -> Str(accept.toTLV.hex),
-        "sign" -> Str(sign.toTLV.hex),
+        "offer" -> Str(LnMessage(offer.toTLV).hex),
+        "accept" -> Str(LnMessage(accept.toTLV).hex),
+        "sign" -> Str(LnMessage(sign.toTLV).hex),
         "fundingTxId" -> Str(fundingTx.txIdBE.hex),
         "fundingTx" -> Str(fundingTx.hex)
       )
@@ -201,9 +194,9 @@ object DLCStatus {
         "state" -> Str(state.toString),
         "paramHash" -> Str(paramHash.hex),
         "isInitiator" -> Bool(isInitiator),
-        "offer" -> Str(offer.toTLV.hex),
-        "accept" -> Str(accept.toTLV.hex),
-        "sign" -> Str(sign.toTLV.hex),
+        "offer" -> Str(LnMessage(offer.toTLV).hex),
+        "accept" -> Str(LnMessage(accept.toTLV).hex),
+        "sign" -> Str(LnMessage(sign.toTLV).hex),
         "fundingTxId" -> Str(fundingTx.txIdBE.hex),
         "fundingTx" -> Str(fundingTx.hex)
       )
@@ -229,9 +222,9 @@ object DLCStatus {
         "state" -> Str(state.toString),
         "paramHash" -> Str(paramHash.hex),
         "isInitiator" -> Bool(isInitiator),
-        "offer" -> Str(offer.toTLV.hex),
-        "accept" -> Str(accept.toTLV.hex),
-        "sign" -> Str(sign.toTLV.hex),
+        "offer" -> Str(LnMessage(offer.toTLV).hex),
+        "accept" -> Str(LnMessage(accept.toTLV).hex),
+        "sign" -> Str(LnMessage(sign.toTLV).hex),
         "fundingTxId" -> Str(fundingTx.txIdBE.hex),
         "fundingTx" -> Str(fundingTx.hex),
         "oracleSigs" -> oracleSigs.map(sig => Str(sig.hex)),
@@ -239,7 +232,7 @@ object DLCStatus {
         "cet" -> Str(cet.hex)
       )
 
-    override def closingTx: Transaction = cet
+    override lazy val closingTx: Transaction = cet
   }
 
   /** The state where one of the CETs has been accepted by the network
@@ -386,9 +379,9 @@ object DLCStatus {
         "state" -> Str(state.toString),
         "paramHash" -> Str(paramHash.hex),
         "isInitiator" -> Bool(isInitiator),
-        "offer" -> Str(offer.toTLV.hex),
-        "accept" -> Str(accept.toTLV.hex),
-        "sign" -> Str(sign.toTLV.hex),
+        "offer" -> Str(LnMessage(offer.toTLV).hex),
+        "accept" -> Str(LnMessage(accept.toTLV).hex),
+        "sign" -> Str(LnMessage(sign.toTLV).hex),
         "fundingTxId" -> Str(fundingTx.txIdBE.hex),
         "fundingTx" -> Str(fundingTx.hex),
         "oracleSig" -> Str(oracleSig.hex),
@@ -398,7 +391,7 @@ object DLCStatus {
       )
     }
 
-    override def closingTx: Transaction = cet
+    override lazy val closingTx: Transaction = cet
   }
 
   /** The state where the DLC refund transaction has been
@@ -420,16 +413,16 @@ object DLCStatus {
         "state" -> Str(state.toString),
         "paramHash" -> Str(paramHash.hex),
         "isInitiator" -> Bool(isInitiator),
-        "offer" -> Str(offer.toTLV.hex),
-        "accept" -> Str(accept.toTLV.hex),
-        "sign" -> Str(sign.toTLV.hex),
+        "offer" -> Str(LnMessage(offer.toTLV).hex),
+        "accept" -> Str(LnMessage(accept.toTLV).hex),
+        "sign" -> Str(LnMessage(sign.toTLV).hex),
         "fundingTxId" -> Str(fundingTx.txIdBE.hex),
         "fundingTx" -> Str(fundingTx.hex),
         "refundTxId" -> Str(refundTx.txIdBE.hex),
         "refundTx" -> Str(refundTx.hex)
       )
 
-    override def closingTx: Transaction = refundTx
+    override lazy val closingTx: Transaction = refundTx
   }
 
   def fromJson(json: Value): DLCStatus = {
@@ -438,10 +431,15 @@ object DLCStatus {
     val state = DLCState.fromString(obj("state").str)
     val paramHash = Sha256DigestBE(obj("paramHash").str)
     val isInitiator = obj("isInitiator").bool
-    val offer = DLCOffer.fromTLV(DLCOfferTLV(obj("offer").str))
+    val offer = DLCOffer.fromTLV(
+      LnMessageFactory(DLCOfferTLV).fromHex(obj("offer").str).tlv)
 
-    lazy val accept = DLCAccept.fromTLV(DLCAcceptTLV(obj("accept").str), offer)
-    lazy val sign = DLCSign.fromTLV(DLCSignTLV(obj("sign").str), offer)
+    lazy val accept = DLCAccept.fromTLV(
+      LnMessageFactory(DLCAcceptTLV).fromHex(obj("accept").str).tlv,
+      offer)
+    lazy val sign = DLCSign.fromTLV(
+      LnMessageFactory(DLCSignTLV).fromHex(obj("sign").str).tlv,
+      offer)
     lazy val fundingTx = Transaction(obj("fundingTx").str)
     lazy val cet = Transaction(obj("cet").str)
     lazy val refundTx = Transaction(obj("refundTx").str)

--- a/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/dlc/DLCStatus.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/dlc/DLCStatus.scala
@@ -217,6 +217,15 @@ object DLCStatus {
       extends ClosedDLCStatus {
     override val state: DLCState = DLCState.Claimed
 
+    val outcome: DLCOutcomeType = {
+      offer.oracleAndContractInfo.findOutcome(oracleSigs) match {
+        case Some(outcome) => outcome
+        case None =>
+          throw new IllegalArgumentException(
+            s"No outcome found for signatures: $oracleSigs")
+      }
+    }
+
     override lazy val toJson: Value =
       Obj(
         "state" -> Str(state.toString),

--- a/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/dlc/DLCStatus.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/dlc/DLCStatus.scala
@@ -4,7 +4,10 @@ import org.bitcoins.commons.jsonmodels.dlc.DLCMessage._
 import org.bitcoins.core.policy.Policy
 import org.bitcoins.core.protocol.script.P2WSHWitnessV0
 import org.bitcoins.core.protocol.tlv.{
+  DLCAcceptTLV,
+  DLCOfferTLV,
   DLCOutcomeType,
+  DLCSignTLV,
   EnumOutcome,
   UnsignedNumericOutcome
 }
@@ -64,12 +67,12 @@ object DLCStatus {
       Accepted(paramHash, isInitiator, offer, accept)
     }
 
-    override val toJson: Value =
+    override lazy val toJson: Value =
       Obj(
         "state" -> Str(state.toString),
         "paramHash" -> Str(paramHash.hex),
         "isInitiator" -> Bool(isInitiator),
-        "offer" -> offer.toJson
+        "offer" -> Str(offer.toTLV.hex)
       )
   }
 
@@ -88,13 +91,13 @@ object DLCStatus {
       Signed(paramHash, isInitiator, offer, accept, sign)
     }
 
-    override val toJson: Value =
+    override lazy val toJson: Value =
       Obj(
         "state" -> Str(state.toString),
         "paramHash" -> Str(paramHash.hex),
         "isInitiator" -> Bool(isInitiator),
-        "offer" -> offer.toJson,
-        "accept" -> accept.toJson
+        "offer" -> Str(offer.toTLV.hex),
+        "accept" -> Str(accept.toTLV.hex)
       )
   }
 
@@ -120,14 +123,14 @@ object DLCStatus {
       toBroadcasted(fundingTx).toConfirmed
     }
 
-    override val toJson: Value =
+    override lazy val toJson: Value =
       Obj(
         "state" -> Str(state.toString),
         "paramHash" -> Str(paramHash.hex),
         "isInitiator" -> Bool(isInitiator),
-        "offer" -> offer.toJson,
-        "accept" -> accept.toJson,
-        "sign" -> sign.toJson
+        "offer" -> Str(offer.toTLV.hex),
+        "accept" -> Str(accept.toTLV.hex),
+        "sign" -> Str(sign.toTLV.hex)
       )
   }
 
@@ -149,14 +152,14 @@ object DLCStatus {
       Confirmed(paramHash, isInitiator, offer, accept, sign, fundingTx)
     }
 
-    override val toJson: Value =
+    override lazy val toJson: Value =
       Obj(
         "state" -> Str(state.toString),
         "paramHash" -> Str(paramHash.hex),
         "isInitiator" -> Bool(isInitiator),
-        "offer" -> offer.toJson,
-        "accept" -> accept.toJson,
-        "sign" -> sign.toJson,
+        "offer" -> Str(offer.toTLV.hex),
+        "accept" -> Str(accept.toTLV.hex),
+        "sign" -> Str(sign.toTLV.hex),
         "fundingTxId" -> Str(fundingTx.txIdBE.hex),
         "fundingTx" -> Str(fundingTx.hex)
       )
@@ -177,7 +180,7 @@ object DLCStatus {
     override val state: DLCState = DLCState.Confirmed
 
     def toClaimed(
-        oracleSig: SchnorrDigitalSignature,
+        oracleSigs: Vector[SchnorrDigitalSignature],
         cet: Transaction): Claimed = {
       Claimed(paramHash,
               isInitiator,
@@ -185,7 +188,7 @@ object DLCStatus {
               accept,
               sign,
               fundingTx,
-              oracleSig,
+              oracleSigs,
               cet)
     }
 
@@ -193,14 +196,14 @@ object DLCStatus {
       RemoteClaimed(paramHash, isInitiator, offer, accept, sign, fundingTx, cet)
     }
 
-    override val toJson: Value =
+    override lazy val toJson: Value =
       Obj(
         "state" -> Str(state.toString),
         "paramHash" -> Str(paramHash.hex),
         "isInitiator" -> Bool(isInitiator),
-        "offer" -> offer.toJson,
-        "accept" -> accept.toJson,
-        "sign" -> sign.toJson,
+        "offer" -> Str(offer.toTLV.hex),
+        "accept" -> Str(accept.toTLV.hex),
+        "sign" -> Str(sign.toTLV.hex),
         "fundingTxId" -> Str(fundingTx.txIdBE.hex),
         "fundingTx" -> Str(fundingTx.hex)
       )
@@ -216,22 +219,22 @@ object DLCStatus {
       accept: DLCAccept,
       sign: DLCSign,
       fundingTx: Transaction,
-      oracleSig: SchnorrDigitalSignature,
+      oracleSigs: Vector[SchnorrDigitalSignature],
       cet: Transaction)
       extends ClosedDLCStatus {
     override val state: DLCState = DLCState.Claimed
 
-    override val toJson: Value =
+    override lazy val toJson: Value =
       Obj(
         "state" -> Str(state.toString),
         "paramHash" -> Str(paramHash.hex),
         "isInitiator" -> Bool(isInitiator),
-        "offer" -> offer.toJson,
-        "accept" -> accept.toJson,
-        "sign" -> sign.toJson,
+        "offer" -> Str(offer.toTLV.hex),
+        "accept" -> Str(accept.toTLV.hex),
+        "sign" -> Str(sign.toTLV.hex),
         "fundingTxId" -> Str(fundingTx.txIdBE.hex),
         "fundingTx" -> Str(fundingTx.hex),
-        "oracleSig" -> Str(oracleSig.hex),
+        "oracleSigs" -> oracleSigs.map(sig => Str(sig.hex)),
         "cetTxId" -> Str(cet.txIdBE.hex),
         "cet" -> Str(cet.hex)
       )
@@ -375,9 +378,9 @@ object DLCStatus {
         "state" -> Str(state.toString),
         "paramHash" -> Str(paramHash.hex),
         "isInitiator" -> Bool(isInitiator),
-        "offer" -> offer.toJson,
-        "accept" -> accept.toJson,
-        "sign" -> sign.toJson,
+        "offer" -> Str(offer.toTLV.hex),
+        "accept" -> Str(accept.toTLV.hex),
+        "sign" -> Str(sign.toTLV.hex),
         "fundingTxId" -> Str(fundingTx.txIdBE.hex),
         "fundingTx" -> Str(fundingTx.hex),
         "oracleSig" -> Str(oracleSig.hex),
@@ -402,14 +405,14 @@ object DLCStatus {
       extends ClosedDLCStatus {
     override val state: DLCState = DLCState.Refunded
 
-    override val toJson: Value =
+    override lazy val toJson: Value =
       Obj(
         "state" -> Str(state.toString),
         "paramHash" -> Str(paramHash.hex),
         "isInitiator" -> Bool(isInitiator),
-        "offer" -> offer.toJson,
-        "accept" -> accept.toJson,
-        "sign" -> sign.toJson,
+        "offer" -> Str(offer.toTLV.hex),
+        "accept" -> Str(accept.toTLV.hex),
+        "sign" -> Str(sign.toTLV.hex),
         "fundingTxId" -> Str(fundingTx.txIdBE.hex),
         "fundingTx" -> Str(fundingTx.hex),
         "refundTxId" -> Str(refundTx.txIdBE.hex),
@@ -425,14 +428,17 @@ object DLCStatus {
     val state = DLCState.fromString(obj("state").str)
     val paramHash = Sha256DigestBE(obj("paramHash").str)
     val isInitiator = obj("isInitiator").bool
-    val offer = DLCOffer.fromJson(obj("offer"))
+    val offer = DLCOffer.fromTLV(DLCOfferTLV(obj("offer").str))
 
-    lazy val accept = DLCAccept.fromJson(obj("accept"))
-    lazy val sign = DLCSign.fromJson(obj("sign"))
+    lazy val accept = DLCAccept.fromTLV(DLCAcceptTLV(obj("accept").str), offer)
+    lazy val sign = DLCSign.fromTLV(DLCSignTLV(obj("sign").str), offer)
     lazy val fundingTx = Transaction(obj("fundingTx").str)
     lazy val cet = Transaction(obj("cet").str)
     lazy val refundTx = Transaction(obj("refundTx").str)
-    lazy val oracleSig = SchnorrDigitalSignature(obj("oracleSig").str)
+    lazy val oracleSigs =
+      obj("oracleSigs").arr
+        .map(value => SchnorrDigitalSignature(value.str))
+        .toVector
 
     state match {
       case DLCState.Offered =>
@@ -452,7 +458,7 @@ object DLCStatus {
                 accept,
                 sign,
                 fundingTx,
-                oracleSig,
+                oracleSigs,
                 cet)
       case DLCState.RemoteClaimed =>
         RemoteClaimed(paramHash,
@@ -500,12 +506,13 @@ object DLCStatus {
     }
   }
 
-  def getOracleSignature(status: DLCStatus): Option[SchnorrDigitalSignature] = {
+  def getOracleSignatures(
+      status: DLCStatus): Option[Vector[SchnorrDigitalSignature]] = {
     status match {
       case remoteClaimed: RemoteClaimed =>
-        Some(remoteClaimed.oracleSig)
+        Some(Vector(remoteClaimed.oracleSig))
       case claimed: Claimed =>
-        Some(claimed.oracleSig)
+        Some(claimed.oracleSigs)
       case _: Offered | _: Accepted | _: Signed | _: BroadcastedDLCStatus |
           _: Refunded =>
         None

--- a/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/dlc/RoundingIntervals.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/dlc/RoundingIntervals.scala
@@ -8,7 +8,7 @@ case class RoundingIntervals(intervalStarts: Vector[(BigDecimal, Long)]) {
 
   def intervalContaining(
       outcome: BigDecimal): (BigDecimal, BigDecimal, Long) = {
-    // Using Long.MaxValue garuntees that index will point to index of right endpoint of interval
+    // Using Long.MaxValue guarantees that index will point to index of right endpoint of interval
     val index =
       intervalStarts.search((outcome, Long.MaxValue)).insertionPoint - 1
 
@@ -27,7 +27,7 @@ case class RoundingIntervals(intervalStarts: Vector[(BigDecimal, Long)]) {
   }
 
   def roundingModulusAt(outcome: BigDecimal): Long = {
-    // Using Long.MaxValue garuntees that index will point to index of right endpoint of interval
+    // Using Long.MaxValue guarantees that index will point to index of right endpoint of interval
     val index =
       intervalStarts.search((outcome, Long.MaxValue)).insertionPoint - 1
 

--- a/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/dlc/SerializedDLCStatus.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/dlc/SerializedDLCStatus.scala
@@ -1,0 +1,552 @@
+package org.bitcoins.commons.jsonmodels.dlc
+
+import org.bitcoins.commons.jsonmodels.dlc.DLCMessage._
+import org.bitcoins.core.currency.{CurrencyUnit, Satoshis}
+import org.bitcoins.core.number.UInt32
+import org.bitcoins.core.protocol.BlockStamp
+import org.bitcoins.core.protocol.tlv.{
+  ContractInfoTLV,
+  DLCOutcomeType,
+  EnumOutcome,
+  UnsignedNumericOutcome
+}
+import org.bitcoins.core.wallet.fee.{FeeUnit, SatoshisPerVirtualByte}
+import org.bitcoins.crypto._
+import scodec.bits.ByteVector
+import ujson._
+
+sealed trait SerializedDLCStatus {
+  def paramHash: Sha256DigestBE
+  def isInitiator: Boolean
+  def state: DLCState
+  def tempContractId: Sha256Digest
+  def oracleInfo: OracleInfo
+  def contractInfo: ContractInfo
+  def timeouts: DLCTimeouts
+  def feeRate: FeeUnit
+  def totalCollateral: CurrencyUnit
+  def localCollateral: CurrencyUnit
+  def remoteCollateral: CurrencyUnit = totalCollateral - localCollateral
+
+  lazy val statusString: String = state.toString
+
+  def toJson: Value
+}
+
+sealed trait AcceptedSerializedDLCStatus extends SerializedDLCStatus {
+  def contractId: ByteVector
+}
+
+sealed trait BroadcastedSerializedDLCStatus
+    extends AcceptedSerializedDLCStatus {
+  def fundingTxId: DoubleSha256DigestBE
+}
+
+sealed trait ClosedSerializedDLCStatus extends BroadcastedSerializedDLCStatus {
+  def closingTxId: DoubleSha256DigestBE
+}
+
+sealed trait ClaimedSerializedDLCStatus extends ClosedSerializedDLCStatus {
+  def outcome: DLCOutcomeType
+  def oracleSigs: Vector[SchnorrDigitalSignature]
+}
+
+object SerializedDLCStatus {
+
+  case class SerializedOffered(
+      paramHash: Sha256DigestBE,
+      isInitiator: Boolean,
+      tempContractId: Sha256Digest,
+      oracleInfo: OracleInfo,
+      contractInfo: ContractInfo,
+      timeouts: DLCTimeouts,
+      feeRate: FeeUnit,
+      totalCollateral: CurrencyUnit,
+      localCollateral: CurrencyUnit
+  ) extends SerializedDLCStatus {
+    override val state: DLCState = DLCState.Offered
+
+    override lazy val toJson: Value = Obj(
+      "state" -> Str(statusString),
+      "paramHash" -> Str(paramHash.hex),
+      "isInitiator" -> Bool(isInitiator),
+      "tempContractId" -> Str(tempContractId.hex),
+      "oracleInfo" -> Str(oracleInfo.hex),
+      "contractInfo" -> Str(contractInfo.toTLV.hex),
+      "contractMaturity" -> Num(
+        timeouts.contractMaturity.toUInt32.toLong.toDouble),
+      "contractTimeout" -> Num(
+        timeouts.contractTimeout.toUInt32.toLong.toDouble),
+      "feeRate" -> Num(feeRate.toLong.toDouble),
+      "totalCollateral" -> Num(totalCollateral.satoshis.toLong.toDouble),
+      "localCollateral" -> Num(localCollateral.satoshis.toLong.toDouble),
+      "remoteCollateral" -> Num(remoteCollateral.satoshis.toLong.toDouble)
+    )
+  }
+
+  case class SerializedAccepted(
+      paramHash: Sha256DigestBE,
+      isInitiator: Boolean,
+      tempContractId: Sha256Digest,
+      contractId: ByteVector,
+      oracleInfo: OracleInfo,
+      contractInfo: ContractInfo,
+      timeouts: DLCTimeouts,
+      feeRate: FeeUnit,
+      totalCollateral: CurrencyUnit,
+      localCollateral: CurrencyUnit)
+      extends AcceptedSerializedDLCStatus {
+    override val state: DLCState = DLCState.Accepted
+
+    override lazy val toJson: Value = Obj(
+      "state" -> Str(statusString),
+      "paramHash" -> Str(paramHash.hex),
+      "isInitiator" -> Bool(isInitiator),
+      "tempContractId" -> Str(tempContractId.hex),
+      "contractId" -> Str(contractId.toHex),
+      "oracleInfo" -> Str(oracleInfo.hex),
+      "contractInfo" -> Str(contractInfo.toTLV.hex),
+      "contractMaturity" -> Num(
+        timeouts.contractMaturity.toUInt32.toLong.toDouble),
+      "contractTimeout" -> Num(
+        timeouts.contractTimeout.toUInt32.toLong.toDouble),
+      "feeRate" -> Num(feeRate.toLong.toDouble),
+      "totalCollateral" -> Num(totalCollateral.satoshis.toLong.toDouble),
+      "localCollateral" -> Num(localCollateral.satoshis.toLong.toDouble),
+      "remoteCollateral" -> Num(remoteCollateral.satoshis.toLong.toDouble)
+    )
+  }
+
+  case class SerializedSigned(
+      paramHash: Sha256DigestBE,
+      isInitiator: Boolean,
+      tempContractId: Sha256Digest,
+      contractId: ByteVector,
+      oracleInfo: OracleInfo,
+      contractInfo: ContractInfo,
+      timeouts: DLCTimeouts,
+      feeRate: FeeUnit,
+      totalCollateral: CurrencyUnit,
+      localCollateral: CurrencyUnit)
+      extends AcceptedSerializedDLCStatus {
+    override val state: DLCState = DLCState.Signed
+
+    override lazy val toJson: Value = Obj(
+      "state" -> Str(statusString),
+      "paramHash" -> Str(paramHash.hex),
+      "isInitiator" -> Bool(isInitiator),
+      "tempContractId" -> Str(tempContractId.hex),
+      "contractId" -> Str(contractId.toHex),
+      "oracleInfo" -> Str(oracleInfo.hex),
+      "contractInfo" -> Str(contractInfo.toTLV.hex),
+      "contractMaturity" -> Num(
+        timeouts.contractMaturity.toUInt32.toLong.toDouble),
+      "contractTimeout" -> Num(
+        timeouts.contractTimeout.toUInt32.toLong.toDouble),
+      "feeRate" -> Num(feeRate.toLong.toDouble),
+      "totalCollateral" -> Num(totalCollateral.satoshis.toLong.toDouble),
+      "localCollateral" -> Num(localCollateral.satoshis.toLong.toDouble),
+      "remoteCollateral" -> Num(remoteCollateral.satoshis.toLong.toDouble)
+    )
+  }
+
+  case class SerializedBroadcasted(
+      paramHash: Sha256DigestBE,
+      isInitiator: Boolean,
+      tempContractId: Sha256Digest,
+      contractId: ByteVector,
+      oracleInfo: OracleInfo,
+      contractInfo: ContractInfo,
+      timeouts: DLCTimeouts,
+      feeRate: FeeUnit,
+      totalCollateral: CurrencyUnit,
+      localCollateral: CurrencyUnit,
+      fundingTxId: DoubleSha256DigestBE)
+      extends BroadcastedSerializedDLCStatus {
+    override val state: DLCState = DLCState.Broadcasted
+
+    override lazy val toJson: Value = Obj(
+      "state" -> Str(statusString),
+      "paramHash" -> Str(paramHash.hex),
+      "isInitiator" -> Bool(isInitiator),
+      "tempContractId" -> Str(tempContractId.hex),
+      "contractId" -> Str(contractId.toHex),
+      "oracleInfo" -> Str(oracleInfo.hex),
+      "contractInfo" -> Str(contractInfo.toTLV.hex),
+      "contractMaturity" -> Num(
+        timeouts.contractMaturity.toUInt32.toLong.toDouble),
+      "contractTimeout" -> Num(
+        timeouts.contractTimeout.toUInt32.toLong.toDouble),
+      "feeRate" -> Num(feeRate.toLong.toDouble),
+      "totalCollateral" -> Num(totalCollateral.satoshis.toLong.toDouble),
+      "localCollateral" -> Num(localCollateral.satoshis.toLong.toDouble),
+      "remoteCollateral" -> Num(remoteCollateral.satoshis.toLong.toDouble),
+      "fundingTxId" -> Str(fundingTxId.hex)
+    )
+  }
+
+  case class SerializedConfirmed(
+      paramHash: Sha256DigestBE,
+      isInitiator: Boolean,
+      tempContractId: Sha256Digest,
+      contractId: ByteVector,
+      oracleInfo: OracleInfo,
+      contractInfo: ContractInfo,
+      timeouts: DLCTimeouts,
+      feeRate: FeeUnit,
+      totalCollateral: CurrencyUnit,
+      localCollateral: CurrencyUnit,
+      fundingTxId: DoubleSha256DigestBE)
+      extends BroadcastedSerializedDLCStatus {
+    override val state: DLCState = DLCState.Confirmed
+
+    override lazy val toJson: Value = Obj(
+      "state" -> Str(statusString),
+      "paramHash" -> Str(paramHash.hex),
+      "isInitiator" -> Bool(isInitiator),
+      "tempContractId" -> Str(tempContractId.hex),
+      "contractId" -> Str(contractId.toHex),
+      "oracleInfo" -> Str(oracleInfo.hex),
+      "contractInfo" -> Str(contractInfo.toTLV.hex),
+      "contractMaturity" -> Num(
+        timeouts.contractMaturity.toUInt32.toLong.toDouble),
+      "contractTimeout" -> Num(
+        timeouts.contractTimeout.toUInt32.toLong.toDouble),
+      "feeRate" -> Num(feeRate.toLong.toDouble),
+      "totalCollateral" -> Num(totalCollateral.satoshis.toLong.toDouble),
+      "localCollateral" -> Num(localCollateral.satoshis.toLong.toDouble),
+      "remoteCollateral" -> Num(remoteCollateral.satoshis.toLong.toDouble),
+      "fundingTxId" -> Str(fundingTxId.hex)
+    )
+  }
+
+  case class SerializedClaimed(
+      paramHash: Sha256DigestBE,
+      isInitiator: Boolean,
+      tempContractId: Sha256Digest,
+      contractId: ByteVector,
+      oracleInfo: OracleInfo,
+      contractInfo: ContractInfo,
+      timeouts: DLCTimeouts,
+      feeRate: FeeUnit,
+      totalCollateral: CurrencyUnit,
+      localCollateral: CurrencyUnit,
+      fundingTxId: DoubleSha256DigestBE,
+      closingTxId: DoubleSha256DigestBE,
+      oracleSigs: Vector[SchnorrDigitalSignature],
+      outcome: DLCOutcomeType)
+      extends ClaimedSerializedDLCStatus {
+    override val state: DLCState = DLCState.Claimed
+
+    override lazy val toJson: Value = {
+      val outcomeJs = outcome match {
+        case EnumOutcome(outcome) =>
+          Str(outcome)
+        case UnsignedNumericOutcome(digits) =>
+          Arr.from(digits.map(num => Num(num)))
+      }
+
+      Obj(
+        "state" -> Str(statusString),
+        "paramHash" -> Str(paramHash.hex),
+        "isInitiator" -> Bool(isInitiator),
+        "tempContractId" -> Str(tempContractId.hex),
+        "contractId" -> Str(contractId.toHex),
+        "oracleInfo" -> Str(oracleInfo.hex),
+        "contractInfo" -> Str(contractInfo.toTLV.hex),
+        "contractMaturity" -> Num(
+          timeouts.contractMaturity.toUInt32.toLong.toDouble),
+        "contractTimeout" -> Num(
+          timeouts.contractTimeout.toUInt32.toLong.toDouble),
+        "feeRate" -> Num(feeRate.toLong.toDouble),
+        "totalCollateral" -> Num(totalCollateral.satoshis.toLong.toDouble),
+        "localCollateral" -> Num(localCollateral.satoshis.toLong.toDouble),
+        "remoteCollateral" -> Num(remoteCollateral.satoshis.toLong.toDouble),
+        "fundingTxId" -> Str(fundingTxId.hex),
+        "closingTxId" -> Str(closingTxId.hex),
+        "oracleSigs" -> oracleSigs.map(sig => Str(sig.hex)),
+        "outcome" -> outcomeJs
+      )
+    }
+  }
+
+  case class SerializedRemoteClaimed(
+      paramHash: Sha256DigestBE,
+      isInitiator: Boolean,
+      tempContractId: Sha256Digest,
+      contractId: ByteVector,
+      oracleInfo: OracleInfo,
+      contractInfo: ContractInfo,
+      timeouts: DLCTimeouts,
+      feeRate: FeeUnit,
+      totalCollateral: CurrencyUnit,
+      localCollateral: CurrencyUnit,
+      fundingTxId: DoubleSha256DigestBE,
+      closingTxId: DoubleSha256DigestBE,
+      oracleSigs: Vector[SchnorrDigitalSignature],
+      outcome: DLCOutcomeType)
+      extends ClaimedSerializedDLCStatus {
+    override val state: DLCState = DLCState.RemoteClaimed
+
+    override lazy val toJson: Value = {
+      val outcomeJs = outcome match {
+        case EnumOutcome(outcome) =>
+          Str(outcome)
+        case UnsignedNumericOutcome(digits) =>
+          Arr.from(digits.map(num => Num(num)))
+      }
+
+      Obj(
+        "state" -> Str(statusString),
+        "paramHash" -> Str(paramHash.hex),
+        "isInitiator" -> Bool(isInitiator),
+        "tempContractId" -> Str(tempContractId.hex),
+        "contractId" -> Str(contractId.toHex),
+        "oracleInfo" -> Str(oracleInfo.hex),
+        "contractInfo" -> Str(contractInfo.toTLV.hex),
+        "contractMaturity" -> Num(
+          timeouts.contractMaturity.toUInt32.toLong.toDouble),
+        "contractTimeout" -> Num(
+          timeouts.contractTimeout.toUInt32.toLong.toDouble),
+        "feeRate" -> Num(feeRate.toLong.toDouble),
+        "totalCollateral" -> Num(totalCollateral.satoshis.toLong.toDouble),
+        "localCollateral" -> Num(localCollateral.satoshis.toLong.toDouble),
+        "remoteCollateral" -> Num(remoteCollateral.satoshis.toLong.toDouble),
+        "fundingTxId" -> Str(fundingTxId.hex),
+        "closingTxId" -> Str(closingTxId.hex),
+        "oracleSigs" -> oracleSigs.map(sig => Str(sig.hex)),
+        "outcome" -> outcomeJs
+      )
+    }
+  }
+
+  case class SerializedRefunded(
+      paramHash: Sha256DigestBE,
+      isInitiator: Boolean,
+      tempContractId: Sha256Digest,
+      contractId: ByteVector,
+      oracleInfo: OracleInfo,
+      contractInfo: ContractInfo,
+      timeouts: DLCTimeouts,
+      feeRate: FeeUnit,
+      totalCollateral: CurrencyUnit,
+      localCollateral: CurrencyUnit,
+      fundingTxId: DoubleSha256DigestBE,
+      closingTxId: DoubleSha256DigestBE)
+      extends ClosedSerializedDLCStatus {
+    override val state: DLCState = DLCState.Refunded
+
+    override lazy val toJson: Value =
+      Obj(
+        "state" -> Str(statusString),
+        "paramHash" -> Str(paramHash.hex),
+        "isInitiator" -> Bool(isInitiator),
+        "tempContractId" -> Str(tempContractId.hex),
+        "contractId" -> Str(contractId.toHex),
+        "oracleInfo" -> Str(oracleInfo.hex),
+        "contractInfo" -> Str(contractInfo.toTLV.hex),
+        "contractMaturity" -> Num(
+          timeouts.contractMaturity.toUInt32.toLong.toDouble),
+        "contractTimeout" -> Num(
+          timeouts.contractTimeout.toUInt32.toLong.toDouble),
+        "feeRate" -> Num(feeRate.toLong.toDouble),
+        "totalCollateral" -> Num(totalCollateral.satoshis.toLong.toDouble),
+        "localCollateral" -> Num(localCollateral.satoshis.toLong.toDouble),
+        "remoteCollateral" -> Num(remoteCollateral.satoshis.toLong.toDouble),
+        "fundingTxId" -> Str(fundingTxId.hex),
+        "closingTxId" -> Str(closingTxId.hex)
+      )
+  }
+
+  def getContractId(status: SerializedDLCStatus): Option[ByteVector] = {
+    status match {
+      case status: AcceptedSerializedDLCStatus =>
+        Some(status.contractId)
+      case _: SerializedOffered | _: SerializedAccepted =>
+        None
+    }
+  }
+
+  def getFundingTxId(
+      status: SerializedDLCStatus): Option[DoubleSha256DigestBE] = {
+    status match {
+      case status: BroadcastedSerializedDLCStatus =>
+        Some(status.fundingTxId)
+      case _: SerializedOffered | _: SerializedAccepted | _: SerializedSigned =>
+        None
+    }
+  }
+
+  def getClosingTxId(
+      status: SerializedDLCStatus): Option[DoubleSha256DigestBE] = {
+    status match {
+      case status: ClosedSerializedDLCStatus =>
+        Some(status.closingTxId)
+      case _: SerializedOffered | _: AcceptedSerializedDLCStatus =>
+        None
+    }
+  }
+
+  def getOracleSignatures(
+      status: SerializedDLCStatus): Option[Vector[SchnorrDigitalSignature]] = {
+    status match {
+      case claimed: ClaimedSerializedDLCStatus =>
+        Some(claimed.oracleSigs)
+      case _: SerializedOffered | _: SerializedAccepted | _: SerializedSigned |
+          _: BroadcastedSerializedDLCStatus | _: SerializedRefunded =>
+        None
+    }
+  }
+
+  def fromJson(json: Value): SerializedDLCStatus = {
+    val obj = json.obj
+
+    val paramHash = Sha256DigestBE(obj("paramHash").str)
+    val state = DLCState.fromString(obj("state").str)
+    val isInitiator = obj("isInitiator").bool
+    val tempContractId = Sha256Digest(obj("tempContractId").str)
+    val oracleInfo = OracleInfo(obj("oracleInfo").str)
+    val contractInfoTLV = ContractInfoTLV(obj("contractInfo").str)
+    val contractMaturity = BlockStamp(
+      UInt32(obj("contractMaturity").num.toLong))
+    val contractTimeout = BlockStamp(UInt32(obj("contractTimeout").num.toLong))
+    val feeRate = SatoshisPerVirtualByte.fromLong(obj("feeRate").num.toLong)
+    val totalCollateral = Satoshis(obj("totalCollateral").num.toLong)
+    val localCollateral = Satoshis(obj("localCollateral").num.toLong)
+
+    lazy val contractId = ByteVector.fromValidHex(obj("contractId").str)
+    lazy val fundingTxId = DoubleSha256DigestBE(obj("fundingTxId").str)
+    lazy val closingTxId = DoubleSha256DigestBE(obj("closingTxId").str)
+    lazy val oracleSigs =
+      obj("oracleSigs").arr
+        .map(value => SchnorrDigitalSignature(value.str))
+        .toVector
+
+    lazy val outcomeJs = obj("outcome")
+    lazy val outcome = outcomeJs.strOpt match {
+      case Some(value) => EnumOutcome(value)
+      case None =>
+        val digits = outcomeJs.arr.map(value => value.num.toInt)
+        UnsignedNumericOutcome(digits.toVector)
+    }
+
+    state match {
+      case DLCState.Offered =>
+        SerializedOffered(
+          paramHash,
+          isInitiator,
+          tempContractId,
+          oracleInfo,
+          ContractInfo.fromTLV(contractInfoTLV),
+          DLCTimeouts(contractMaturity, contractTimeout),
+          feeRate,
+          totalCollateral,
+          localCollateral
+        )
+      case DLCState.Accepted =>
+        SerializedAccepted(
+          paramHash,
+          isInitiator,
+          tempContractId,
+          contractId,
+          oracleInfo,
+          ContractInfo.fromTLV(contractInfoTLV),
+          DLCTimeouts(contractMaturity, contractTimeout),
+          feeRate,
+          totalCollateral,
+          localCollateral
+        )
+      case DLCState.Signed =>
+        SerializedSigned(
+          paramHash,
+          isInitiator,
+          tempContractId,
+          contractId,
+          oracleInfo,
+          ContractInfo.fromTLV(contractInfoTLV),
+          DLCTimeouts(contractMaturity, contractTimeout),
+          feeRate,
+          totalCollateral,
+          localCollateral
+        )
+      case DLCState.Broadcasted =>
+        SerializedBroadcasted(
+          paramHash,
+          isInitiator,
+          tempContractId,
+          contractId,
+          oracleInfo,
+          ContractInfo.fromTLV(contractInfoTLV),
+          DLCTimeouts(contractMaturity, contractTimeout),
+          feeRate,
+          totalCollateral,
+          localCollateral,
+          fundingTxId
+        )
+      case DLCState.Confirmed =>
+        SerializedConfirmed(
+          paramHash,
+          isInitiator,
+          tempContractId,
+          contractId,
+          oracleInfo,
+          ContractInfo.fromTLV(contractInfoTLV),
+          DLCTimeouts(contractMaturity, contractTimeout),
+          feeRate,
+          totalCollateral,
+          localCollateral,
+          fundingTxId
+        )
+      case DLCState.Claimed =>
+        SerializedClaimed(
+          paramHash,
+          isInitiator,
+          tempContractId,
+          contractId,
+          oracleInfo,
+          ContractInfo.fromTLV(contractInfoTLV),
+          DLCTimeouts(contractMaturity, contractTimeout),
+          feeRate,
+          totalCollateral,
+          localCollateral,
+          fundingTxId,
+          closingTxId,
+          oracleSigs,
+          outcome
+        )
+      case DLCState.RemoteClaimed =>
+        SerializedRemoteClaimed(
+          paramHash,
+          isInitiator,
+          tempContractId,
+          contractId,
+          oracleInfo,
+          ContractInfo.fromTLV(contractInfoTLV),
+          DLCTimeouts(contractMaturity, contractTimeout),
+          feeRate,
+          totalCollateral,
+          localCollateral,
+          fundingTxId,
+          closingTxId,
+          oracleSigs,
+          outcome
+        )
+      case DLCState.Refunded =>
+        SerializedRefunded(
+          paramHash,
+          isInitiator,
+          tempContractId,
+          contractId,
+          oracleInfo,
+          ContractInfo.fromTLV(contractInfoTLV),
+          DLCTimeouts(contractMaturity, contractTimeout),
+          feeRate,
+          totalCollateral,
+          localCollateral,
+          fundingTxId,
+          closingTxId
+        )
+
+    }
+  }
+}

--- a/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/dlc/SerializedDLCStatus.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/dlc/SerializedDLCStatus.scala
@@ -283,10 +283,11 @@ object SerializedDLCStatus {
       localCollateral: CurrencyUnit,
       fundingTxId: DoubleSha256DigestBE,
       closingTxId: DoubleSha256DigestBE,
-      oracleSigs: Vector[SchnorrDigitalSignature],
+      oracleSig: SchnorrDigitalSignature,
       outcome: DLCOutcomeType)
       extends ClaimedSerializedDLCStatus {
     override val state: DLCState = DLCState.RemoteClaimed
+    override val oracleSigs: Vector[SchnorrDigitalSignature] = Vector(oracleSig)
 
     override lazy val toJson: Value = {
       val outcomeJs = outcome match {
@@ -515,6 +516,8 @@ object SerializedDLCStatus {
           outcome
         )
       case DLCState.RemoteClaimed =>
+        require(oracleSigs.size == 1,
+                "Remote claimed should only have one oracle sig")
         SerializedRemoteClaimed(
           paramHash,
           isInitiator,
@@ -528,7 +531,7 @@ object SerializedDLCStatus {
           localCollateral,
           fundingTxId,
           closingTxId,
-          oracleSigs,
+          oracleSigs.head,
           outcome
         )
       case DLCState.Refunded =>

--- a/app-commons/src/main/scala/org/bitcoins/commons/serializers/Picklers.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/serializers/Picklers.scala
@@ -1,5 +1,7 @@
 package org.bitcoins.commons.serializers
 
+import java.io.File
+import java.nio.file.Path
 import java.time.Instant
 
 import org.bitcoins.commons.jsonmodels.bitcoind.RpcOpts.LockUnspentOutputParameter
@@ -20,6 +22,9 @@ import scodec.bits.ByteVector
 import upickle.default._
 
 object Picklers {
+
+  implicit val pathPickler: ReadWriter[Path] =
+    readwriter[String].bimap(_.toString, str => new File(str).toPath)
 
   implicit val byteVectorPickler: ReadWriter[ByteVector] =
     readwriter[String].bimap(_.toHex, str => ByteVector.fromValidHex(str))

--- a/app-commons/src/main/scala/org/bitcoins/commons/serializers/Picklers.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/serializers/Picklers.scala
@@ -76,11 +76,21 @@ object Picklers {
   implicit val dlcOfferTLVPickler: ReadWriter[DLCOfferTLV] =
     readwriter[String].bimap(_.hex, DLCOfferTLV.fromHex)
 
+  implicit val lnMessageDLCOfferTLVPickler: ReadWriter[LnMessage[DLCOfferTLV]] =
+    readwriter[String].bimap(_.hex, LnMessageFactory(DLCOfferTLV).fromHex)
+
   implicit val dlcAcceptTLVPickler: ReadWriter[DLCAcceptTLV] =
     readwriter[String].bimap(_.hex, DLCAcceptTLV.fromHex)
 
+  implicit val lnMessageDLCAcceptTLVPickler: ReadWriter[
+    LnMessage[DLCAcceptTLV]] =
+    readwriter[String].bimap(_.hex, LnMessageFactory(DLCAcceptTLV).fromHex)
+
   implicit val dlcSignTLVPickler: ReadWriter[DLCSignTLV] =
     readwriter[String].bimap(_.hex, DLCSignTLV.fromHex)
+
+  implicit val lnMessageDLCSignTLVPickler: ReadWriter[LnMessage[DLCSignTLV]] =
+    readwriter[String].bimap(_.hex, LnMessageFactory(DLCSignTLV).fromHex)
 
   implicit val blockStampPickler: ReadWriter[BlockStamp] =
     readwriter[String].bimap(_.mkString, BlockStamp.fromString)

--- a/app-commons/src/main/scala/org/bitcoins/commons/serializers/Picklers.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/serializers/Picklers.scala
@@ -8,6 +8,7 @@ import org.bitcoins.core.api.wallet.CoinSelectionAlgo
 import org.bitcoins.core.crypto.ExtPublicKey
 import org.bitcoins.core.currency.{Bitcoins, Satoshis}
 import org.bitcoins.core.number.UInt32
+import org.bitcoins.core.protocol.tlv._
 import org.bitcoins.core.protocol.transaction.{Transaction, TransactionOutPoint}
 import org.bitcoins.core.protocol.{BitcoinAddress, BlockStamp}
 import org.bitcoins.core.psbt.InputPSBTRecord.PartialSignature
@@ -15,11 +16,13 @@ import org.bitcoins.core.psbt.PSBT
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.core.wallet.utxo.AddressLabelTag
 import org.bitcoins.crypto._
+import scodec.bits.ByteVector
 import upickle.default._
 
 object Picklers {
 
-  import org.bitcoins.crypto.DoubleSha256DigestBE
+  implicit val byteVectorPickler: ReadWriter[ByteVector] =
+    readwriter[String].bimap(_.toHex, str => ByteVector.fromValidHex(str))
 
   implicit val bitcoinAddressPickler: ReadWriter[BitcoinAddress] =
     readwriter[String]
@@ -60,6 +63,9 @@ object Picklers {
   implicit val contractInfoPickler: ReadWriter[ContractInfo] =
     readwriter[String].bimap(_.hex, ContractInfo.fromHex)
 
+  implicit val contractInfoTLVPickler: ReadWriter[ContractInfoTLV] =
+    readwriter[String].bimap(_.hex, ContractInfoTLV.fromHex)
+
   implicit val schnorrDigitalSignaturePickler: ReadWriter[
     SchnorrDigitalSignature] =
     readwriter[String].bimap(_.hex, SchnorrDigitalSignature.fromHex)
@@ -67,17 +73,14 @@ object Picklers {
   implicit val partialSignaturePickler: ReadWriter[PartialSignature] =
     readwriter[String].bimap(_.hex, PartialSignature.fromHex)
 
-  implicit val dlcOfferPickler: ReadWriter[DLCOffer] =
-    readwriter[String]
-      .bimap(_.toJsonStr, str => DLCOffer.fromJson(ujson.read(str)))
+  implicit val dlcOfferTLVPickler: ReadWriter[DLCOfferTLV] =
+    readwriter[String].bimap(_.hex, DLCOfferTLV.fromHex)
 
-  implicit val dlcAcceptPickler: ReadWriter[DLCAccept] =
-    readwriter[String]
-      .bimap(_.toJsonStr, str => DLCAccept.fromJson(ujson.read(str).obj))
+  implicit val dlcAcceptTLVPickler: ReadWriter[DLCAcceptTLV] =
+    readwriter[String].bimap(_.hex, DLCAcceptTLV.fromHex)
 
-  implicit val dlcSignPickler: ReadWriter[DLCSign] =
-    readwriter[String]
-      .bimap(_.toJsonStr, str => DLCSign.fromJson(ujson.read(str).obj))
+  implicit val dlcSignTLVPickler: ReadWriter[DLCSignTLV] =
+    readwriter[String].bimap(_.hex, DLCSignTLV.fromHex)
 
   implicit val blockStampPickler: ReadWriter[BlockStamp] =
     readwriter[String].bimap(_.mkString, BlockStamp.fromString)
@@ -89,13 +92,13 @@ object Picklers {
     readwriter[String].bimap(_.hex, Transaction.fromHex)
 
   implicit val extPubKeyPickler: ReadWriter[ExtPublicKey] =
-    readwriter[String].bimap(_.toString, ExtPublicKey.fromString(_))
+    readwriter[String].bimap(_.toString, ExtPublicKey.fromString)
 
   implicit val transactionOutPointPickler: ReadWriter[TransactionOutPoint] =
     readwriter[String].bimap(_.hex, TransactionOutPoint.fromHex)
 
   implicit val coinSelectionAlgoPickler: ReadWriter[CoinSelectionAlgo] =
-    readwriter[String].bimap(_.toString, CoinSelectionAlgo.fromString(_))
+    readwriter[String].bimap(_.toString, CoinSelectionAlgo.fromString)
 
   implicit val addressLabelTagPickler: ReadWriter[AddressLabelTag] =
     readwriter[String].bimap(_.name, AddressLabelTag)

--- a/app/cli/src/main/scala/org/bitcoins/cli/CliReaders.scala
+++ b/app/cli/src/main/scala/org/bitcoins/cli/CliReaders.scala
@@ -1,5 +1,7 @@
 package org.bitcoins.cli
 
+import java.io.File
+import java.nio.file.Path
 import java.time.{Instant, ZoneId, ZonedDateTime}
 
 import org.bitcoins.commons.jsonmodels.bitcoind.RpcOpts.LockUnspentOutputParameter
@@ -22,6 +24,12 @@ import scopt._
 
 /** scopt readers for parsing CLI params and options */
 object CliReaders {
+
+  implicit val pathReads: Read[Path] = new Read[Path] {
+    val arity = 1
+
+    val reads: String => Path = str => new File(str).toPath
+  }
 
   implicit val npReads: Read[NetworkParameters] =
     new Read[NetworkParameters] {

--- a/app/cli/src/main/scala/org/bitcoins/cli/CliReaders.scala
+++ b/app/cli/src/main/scala/org/bitcoins/cli/CliReaders.scala
@@ -10,23 +10,13 @@ import org.bitcoins.core.currency._
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.BlockStamp.BlockTime
 import org.bitcoins.core.protocol._
-import org.bitcoins.core.protocol.tlv.{
-  ContractInfoTLV,
-  DLCAcceptTLV,
-  DLCOfferTLV,
-  DLCSignTLV
-}
+import org.bitcoins.core.protocol.tlv._
 import org.bitcoins.core.protocol.transaction.{Transaction, TransactionOutPoint}
 import org.bitcoins.core.psbt.InputPSBTRecord.PartialSignature
 import org.bitcoins.core.psbt.PSBT
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.core.wallet.utxo.AddressLabelTag
-import org.bitcoins.crypto.{
-  SchnorrDigitalSignature,
-  SchnorrNonce,
-  Sha256Digest,
-  Sha256DigestBE
-}
+import org.bitcoins.crypto._
 import scodec.bits.ByteVector
 import scopt._
 
@@ -224,15 +214,39 @@ object CliReaders {
     override def reads: String => DLCOfferTLV = DLCOfferTLV.fromHex
   }
 
+  implicit val lnMessageDLCOfferTLVReads: Read[LnMessage[DLCOfferTLV]] =
+    new Read[LnMessage[DLCOfferTLV]] {
+      override def arity: Int = 1
+
+      override def reads: String => LnMessage[DLCOfferTLV] =
+        LnMessageFactory(DLCOfferTLV).fromHex
+    }
+
   implicit val dlcAcceptTLVReads: Read[DLCAcceptTLV] = new Read[DLCAcceptTLV] {
     override def arity: Int = 1
 
     override def reads: String => DLCAcceptTLV = DLCAcceptTLV.fromHex
   }
 
+  implicit val lnMessageDLCAcceptTLVReads: Read[LnMessage[DLCAcceptTLV]] =
+    new Read[LnMessage[DLCAcceptTLV]] {
+      override def arity: Int = 1
+
+      override def reads: String => LnMessage[DLCAcceptTLV] =
+        LnMessageFactory(DLCAcceptTLV).fromHex
+    }
+
   implicit val dlcSignTLVReads: Read[DLCSignTLV] = new Read[DLCSignTLV] {
     override def arity: Int = 1
 
     override def reads: String => DLCSignTLV = DLCSignTLV.fromHex
   }
+
+  implicit val lnMessageSignTLVReads: Read[LnMessage[DLCSignTLV]] =
+    new Read[LnMessage[DLCSignTLV]] {
+      override def arity: Int = 1
+
+      override def reads: String => LnMessage[DLCSignTLV] =
+        LnMessageFactory(DLCSignTLV).fromHex
+    }
 }

--- a/app/cli/src/main/scala/org/bitcoins/cli/CliReaders.scala
+++ b/app/cli/src/main/scala/org/bitcoins/cli/CliReaders.scala
@@ -177,7 +177,7 @@ object CliReaders {
       override def arity: Int = 1
 
       override def reads: String => SchnorrDigitalSignature =
-        SchnorrDigitalSignature.fromHex
+        str => SchnorrDigitalSignature.fromHex(str.trim)
     }
 
   implicit val partialSigReads: Read[PartialSignature] =

--- a/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
+++ b/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
@@ -1221,17 +1221,25 @@ object CliCommand {
       refundLT: UInt32)
       extends CliCommand
 
-  case class AcceptDLCOffer(offer: LnMessage[DLCOfferTLV]) extends CliCommand
+  sealed trait AcceptDLCCliCommand extends CliCommand
 
-  case class AcceptDLCOfferFromFile(path: Path) extends CliCommand
+  case class AcceptDLCOffer(offer: LnMessage[DLCOfferTLV])
+      extends AcceptDLCCliCommand
 
-  case class SignDLC(accept: LnMessage[DLCAcceptTLV]) extends CliCommand
+  case class AcceptDLCOfferFromFile(path: Path) extends AcceptDLCCliCommand
 
-  case class SignDLCFromFile(path: Path) extends CliCommand
+  sealed trait SignDLCCliCommand extends CliCommand
 
-  case class AddDLCSigs(sigs: LnMessage[DLCSignTLV]) extends CliCommand
+  case class SignDLC(accept: LnMessage[DLCAcceptTLV]) extends SignDLCCliCommand
 
-  case class AddDLCSigsFromFile(path: Path) extends CliCommand
+  case class SignDLCFromFile(path: Path) extends SignDLCCliCommand
+
+  sealed trait AddDLCSigsCliCommand extends CliCommand
+
+  case class AddDLCSigs(sigs: LnMessage[DLCSignTLV])
+      extends AddDLCSigsCliCommand
+
+  case class AddDLCSigsFromFile(path: Path) extends AddDLCSigsCliCommand
 
   case class GetDLCFundingTx(contractId: ByteVector) extends CliCommand
 

--- a/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
+++ b/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
@@ -1,5 +1,7 @@
 package org.bitcoins.cli
 
+import java.io.File
+import java.nio.file.Path
 import java.time.Instant
 
 import org.bitcoins.cli.CliCommand._
@@ -143,7 +145,6 @@ object ConsoleCli {
         .action((_, conf) => conf.copy(command = IsEmpty))
         .text("Checks if the wallet contains any data"),
       cmd("createdlcoffer")
-        .hidden()
         .action((_, conf) =>
           conf.copy(
             command = CreateDLCOffer(OracleInfo.dummy,
@@ -204,7 +205,6 @@ object ConsoleCli {
               }))
         ),
       cmd("acceptdlcoffer")
-        .hidden()
         .action((_, conf) => conf.copy(command = AcceptDLCOffer(null)))
         .text("Accepts a DLC offer given from another party")
         .children(
@@ -217,8 +217,21 @@ object ConsoleCli {
                 case other => other
               }))
         ),
+      cmd("acceptdlcofferfromfile")
+        .action((_, conf) =>
+          conf.copy(command = AcceptDLCOfferFromFile(new File("").toPath)))
+        .text("Accepts a DLC offer given from another party")
+        .children(
+          arg[Path]("path")
+            .required()
+            .action((path, conf) =>
+              conf.copy(command = conf.command match {
+                case accept: AcceptDLCOfferFromFile =>
+                  accept.copy(path = path)
+                case other => other
+              }))
+        ),
       cmd("signdlc")
-        .hidden()
         .action((_, conf) => conf.copy(command = SignDLC(null)))
         .text("Signs a DLC")
         .children(
@@ -231,8 +244,21 @@ object ConsoleCli {
                 case other => other
               }))
         ),
+      cmd("signdlcfromfile")
+        .action((_, conf) =>
+          conf.copy(command = SignDLCFromFile(new File("").toPath)))
+        .text("Signs a DLC")
+        .children(
+          arg[Path]("path")
+            .required()
+            .action((path, conf) =>
+              conf.copy(command = conf.command match {
+                case signDLC: SignDLCFromFile =>
+                  signDLC.copy(path = path)
+                case other => other
+              }))
+        ),
       cmd("adddlcsigs")
-        .hidden()
         .action((_, conf) => conf.copy(command = AddDLCSigs(null)))
         .text("Adds DLC Signatures into the database")
         .children(
@@ -245,8 +271,21 @@ object ConsoleCli {
                 case other => other
               }))
         ),
+      cmd("adddlcsigsfromfile")
+        .action((_, conf) =>
+          conf.copy(command = AddDLCSigsFromFile(new File("").toPath)))
+        .text("Adds DLC Signatures into the database")
+        .children(
+          arg[Path]("path")
+            .required()
+            .action((path, conf) =>
+              conf.copy(command = conf.command match {
+                case addDLCSigs: AddDLCSigsFromFile =>
+                  addDLCSigs.copy(path = path)
+                case other => other
+              }))
+        ),
       cmd("getdlcfundingtx")
-        .hidden()
         .action((_, conf) => conf.copy(command = GetDLCFundingTx(null)))
         .text("Returns the Funding Tx corresponding to the DLC with the given contractId")
         .children(
@@ -260,7 +299,6 @@ object ConsoleCli {
               }))
         ),
       cmd("broadcastdlcfundingtx")
-        .hidden()
         .action((_, conf) => conf.copy(command = BroadcastDLCFundingTx(null)))
         .text("Broadcasts the funding Tx corresponding to the DLC with the given contractId")
         .children(
@@ -274,7 +312,6 @@ object ConsoleCli {
               }))
         ),
       cmd("executedlc")
-        .hidden()
         .action((_, conf) =>
           conf.copy(command =
             ExecuteDLC(ByteVector.empty, Vector.empty, noBroadcast = false)))
@@ -306,7 +343,6 @@ object ConsoleCli {
               }))
         ),
       cmd("executedlcrefund")
-        .hidden()
         .action((_, conf) =>
           conf.copy(command = ExecuteDLCRefund(null, noBroadcast = false)))
         .text("Executes the Refund transaction for the given DLC")
@@ -946,10 +982,16 @@ object ConsoleCli {
         )
       case AcceptDLCOffer(offer) =>
         RequestParam("acceptdlcoffer", Seq(up.writeJs(offer)))
+      case AcceptDLCOfferFromFile(path) =>
+        RequestParam("acceptdlcofferfromfile", Seq(up.writeJs(path)))
       case SignDLC(accept) =>
         RequestParam("signdlc", Seq(up.writeJs(accept)))
+      case SignDLCFromFile(path) =>
+        RequestParam("signdlcfromfile", Seq(up.writeJs(path)))
       case AddDLCSigs(sigs) =>
         RequestParam("adddlcsigs", Seq(up.writeJs(sigs)))
+      case AddDLCSigsFromFile(path) =>
+        RequestParam("adddlcsigsfromfile", Seq(up.writeJs(path)))
       case ExecuteDLC(contractId, oracleSigs, noBroadcast) =>
         RequestParam("executedlc",
                      Seq(up.writeJs(contractId),
@@ -1181,9 +1223,15 @@ object CliCommand {
 
   case class AcceptDLCOffer(offer: LnMessage[DLCOfferTLV]) extends CliCommand
 
+  case class AcceptDLCOfferFromFile(path: Path) extends CliCommand
+
   case class SignDLC(accept: LnMessage[DLCAcceptTLV]) extends CliCommand
 
+  case class SignDLCFromFile(path: Path) extends CliCommand
+
   case class AddDLCSigs(sigs: LnMessage[DLCSignTLV]) extends CliCommand
+
+  case class AddDLCSigsFromFile(path: Path) extends CliCommand
 
   case class GetDLCFundingTx(contractId: ByteVector) extends CliCommand
 

--- a/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
+++ b/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
@@ -154,7 +154,7 @@ object ConsoleCli {
                                      UInt32.zero)))
         .text("Creates a DLC offer that another party can accept")
         .children(
-          opt[OracleInfo]("oracleInfo")
+          arg[OracleInfo]("oracleInfo")
             .required()
             .action((info, conf) =>
               conf.copy(command = conf.command match {
@@ -162,7 +162,7 @@ object ConsoleCli {
                   offer.copy(oracleInfo = info)
                 case other => other
               })),
-          opt[ContractInfoTLV]("contractInfo")
+          arg[ContractInfoTLV]("contractInfo")
             .required()
             .action((info, conf) =>
               conf.copy(command = conf.command match {
@@ -170,7 +170,7 @@ object ConsoleCli {
                   offer.copy(contractInfo = info)
                 case other => other
               })),
-          opt[Satoshis]("collateral")
+          arg[Satoshis]("collateral")
             .required()
             .action((collateral, conf) =>
               conf.copy(command = conf.command match {
@@ -178,7 +178,7 @@ object ConsoleCli {
                   offer.copy(collateral = collateral)
                 case other => other
               })),
-          opt[SatoshisPerVirtualByte]("feerate")
+          arg[SatoshisPerVirtualByte]("feerate")
             .optional()
             .action((feeRate, conf) =>
               conf.copy(command = conf.command match {
@@ -186,7 +186,7 @@ object ConsoleCli {
                   offer.copy(feeRateOpt = Some(feeRate))
                 case other => other
               })),
-          opt[UInt32]("locktime")
+          arg[UInt32]("locktime")
             .required()
             .action((locktime, conf) =>
               conf.copy(command = conf.command match {
@@ -194,7 +194,7 @@ object ConsoleCli {
                   offer.copy(locktime = locktime)
                 case other => other
               })),
-          opt[UInt32]("refundlocktime")
+          arg[UInt32]("refundlocktime")
             .required()
             .action((refundLT, conf) =>
               conf.copy(command = conf.command match {
@@ -208,7 +208,7 @@ object ConsoleCli {
         .action((_, conf) => conf.copy(command = AcceptDLCOffer(null)))
         .text("Accepts a DLC offer given from another party")
         .children(
-          opt[LnMessage[DLCOfferTLV]]("offer")
+          arg[LnMessage[DLCOfferTLV]]("offer")
             .required()
             .action((offer, conf) =>
               conf.copy(command = conf.command match {
@@ -222,7 +222,7 @@ object ConsoleCli {
         .action((_, conf) => conf.copy(command = SignDLC(null)))
         .text("Signs a DLC")
         .children(
-          opt[LnMessage[DLCAcceptTLV]]("accept")
+          arg[LnMessage[DLCAcceptTLV]]("accept")
             .required()
             .action((accept, conf) =>
               conf.copy(command = conf.command match {
@@ -236,7 +236,7 @@ object ConsoleCli {
         .action((_, conf) => conf.copy(command = AddDLCSigs(null)))
         .text("Adds DLC Signatures into the database")
         .children(
-          opt[LnMessage[DLCSignTLV]]("sigs")
+          arg[LnMessage[DLCSignTLV]]("sigs")
             .required()
             .action((sigs, conf) =>
               conf.copy(command = conf.command match {
@@ -264,7 +264,7 @@ object ConsoleCli {
         .action((_, conf) => conf.copy(command = BroadcastDLCFundingTx(null)))
         .text("Broadcasts the funding Tx corresponding to the DLC with the given contractId")
         .children(
-          opt[ByteVector]("contractId")
+          arg[ByteVector]("contractId")
             .required()
             .action((contractId, conf) =>
               conf.copy(command = conf.command match {
@@ -311,7 +311,7 @@ object ConsoleCli {
           conf.copy(command = ExecuteDLCRefund(null, noBroadcast = false)))
         .text("Executes the Refund transaction for the given DLC")
         .children(
-          opt[ByteVector]("contractId")
+          arg[ByteVector]("contractId")
             .required()
             .action((contractId, conf) =>
               conf.copy(command = conf.command match {

--- a/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
+++ b/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
@@ -11,12 +11,7 @@ import org.bitcoins.core.api.wallet.CoinSelectionAlgo
 import org.bitcoins.core.config.NetworkParameters
 import org.bitcoins.core.currency._
 import org.bitcoins.core.number.UInt32
-import org.bitcoins.core.protocol.tlv.{
-  ContractInfoTLV,
-  DLCAcceptTLV,
-  DLCOfferTLV,
-  DLCSignTLV
-}
+import org.bitcoins.core.protocol.tlv._
 import org.bitcoins.core.protocol.transaction.{
   EmptyTransaction,
   Transaction,
@@ -213,7 +208,7 @@ object ConsoleCli {
         .action((_, conf) => conf.copy(command = AcceptDLCOffer(null)))
         .text("Accepts a DLC offer given from another party")
         .children(
-          opt[DLCOfferTLV]("offer")
+          opt[LnMessage[DLCOfferTLV]]("offer")
             .required()
             .action((offer, conf) =>
               conf.copy(command = conf.command match {
@@ -227,7 +222,7 @@ object ConsoleCli {
         .action((_, conf) => conf.copy(command = SignDLC(null)))
         .text("Signs a DLC")
         .children(
-          opt[DLCAcceptTLV]("accept")
+          opt[LnMessage[DLCAcceptTLV]]("accept")
             .required()
             .action((accept, conf) =>
               conf.copy(command = conf.command match {
@@ -241,7 +236,7 @@ object ConsoleCli {
         .action((_, conf) => conf.copy(command = AddDLCSigs(null)))
         .text("Adds DLC Signatures into the database")
         .children(
-          opt[DLCSignTLV]("sigs")
+          opt[LnMessage[DLCSignTLV]]("sigs")
             .required()
             .action((sigs, conf) =>
               conf.copy(command = conf.command match {
@@ -1184,11 +1179,11 @@ object CliCommand {
       refundLT: UInt32)
       extends CliCommand
 
-  case class AcceptDLCOffer(offer: DLCOfferTLV) extends CliCommand
+  case class AcceptDLCOffer(offer: LnMessage[DLCOfferTLV]) extends CliCommand
 
-  case class SignDLC(accept: DLCAcceptTLV) extends CliCommand
+  case class SignDLC(accept: LnMessage[DLCAcceptTLV]) extends CliCommand
 
-  case class AddDLCSigs(sigs: DLCSignTLV) extends CliCommand
+  case class AddDLCSigs(sigs: LnMessage[DLCSignTLV]) extends CliCommand
 
   case class GetDLCFundingTx(contractId: ByteVector) extends CliCommand
 

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPane.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPane.scala
@@ -28,11 +28,19 @@ class DLCPane(glassPane: VBox) {
   }
 
   private val numOutcomesTF = new TextField {
-    promptText = "Number of Outcomes"
+    promptText = "Number of Outcomes/Digits"
+  }
+
+  private val eventTypeSelector: ComboBox[String] = new ComboBox(
+    Vector("Enum", "Numeric")) {
+    value = "Enum"
   }
 
   private val model =
-    new DLCPaneModel(resultArea, demoOracleArea, numOutcomesTF)
+    new DLCPaneModel(resultArea,
+                     demoOracleArea,
+                     numOutcomesTF,
+                     eventTypeSelector)
 
   model.setUp()
 
@@ -44,7 +52,7 @@ class DLCPane(glassPane: VBox) {
   }
 
   private val oracleButtonHBox = new HBox {
-    children = Seq(numOutcomesTF, demoOracleButton)
+    children = Seq(numOutcomesTF, demoOracleButton, eventTypeSelector)
     spacing = 15
   }
 

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPane.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPane.scala
@@ -1,10 +1,17 @@
 package org.bitcoins.gui.dlc
 
+import java.io.File
+import java.nio.file.Files
+
 import javafx.event.{ActionEvent, EventHandler}
 import org.bitcoins.gui.{GlobalData, TaskRunner}
 import scalafx.geometry.{Insets, Pos}
 import scalafx.scene.control._
 import scalafx.scene.layout._
+import scalafx.stage.FileChooser
+import scalafx.stage.FileChooser.ExtensionFilter
+
+import scala.util.Properties
 
 class DLCPane(glassPane: VBox) {
 
@@ -14,11 +21,41 @@ class DLCPane(glassPane: VBox) {
     text <== GlobalData.statusText
   }
 
-  private val resultArea = new TextArea {
+  private val resultTextArea = new TextArea {
     editable = false
     text = "Click on Offer or Accept to begin."
     wrapText = true
   }
+
+  private val exportButton = new Button("Export Result") {
+    alignmentInParent = Pos.BottomRight
+    onAction = _ => {
+      val txtFilter = new ExtensionFilter("Text Files", "*.txt")
+      val allExtensionFilter = new ExtensionFilter("All Files", "*")
+      val fileChooser = new FileChooser() {
+        extensionFilters.addAll(txtFilter, allExtensionFilter)
+        selectedExtensionFilter = txtFilter
+        initialDirectory = new File(Properties.userHome)
+      }
+
+      val selectedFile = fileChooser.showSaveDialog(null)
+
+      if (selectedFile != null) {
+        val bytes = resultTextArea.text.value.getBytes
+
+        Files.write(selectedFile.toPath, bytes)
+        ()
+      }
+    }
+  }
+
+  private val resultArea = new BorderPane() {
+    padding = Insets(10)
+    center = resultTextArea
+    bottom = exportButton
+  }
+
+  BorderPane.setMargin(exportButton, Insets(10))
 
   private val demoOracleArea = new TextArea {
     editable = false
@@ -28,7 +65,7 @@ class DLCPane(glassPane: VBox) {
   }
 
   private val model =
-    new DLCPaneModel(resultArea, demoOracleArea)
+    new DLCPaneModel(resultTextArea, demoOracleArea)
 
   model.setUp()
 
@@ -55,6 +92,7 @@ class DLCPane(glassPane: VBox) {
   }
 
   private val demoOracleVBox = new VBox {
+    padding = Insets(10)
     children = Seq(demoOracleArea, oracleButtonHBox)
     spacing = 15
   }

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPane.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPane.scala
@@ -32,23 +32,25 @@ class DLCPane(glassPane: VBox) {
 
   model.setUp()
 
-  private val enumOracleButton = new Button {
-    text = "Enum Oracle"
+  private val enumContractButton = new Button {
+    text = "Enum Contract"
     onAction = new EventHandler[ActionEvent] {
-      override def handle(event: ActionEvent): Unit = model.onInitOracle(true)
+      override def handle(event: ActionEvent): Unit = model.onInitContract(true)
     }
   }
 
-  private val numericOracleButton = new Button {
-    text = "Numeric Oracle"
+  private val numericContractButton = new Button {
+    text = "Numeric Contract"
     onAction = new EventHandler[ActionEvent] {
-      override def handle(event: ActionEvent): Unit = model.onInitOracle(false)
+
+      override def handle(event: ActionEvent): Unit =
+        model.onInitContract(false)
     }
   }
 
   private val oracleButtonHBox = new HBox {
     alignment = Pos.Center
-    children = Seq(enumOracleButton, numericOracleButton)
+    children = Seq(enumContractButton, numericContractButton)
     spacing = 15
   }
 

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPane.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPane.scala
@@ -27,32 +27,28 @@ class DLCPane(glassPane: VBox) {
     wrapText = true
   }
 
-  private val numOutcomesTF = new TextField {
-    promptText = "Number of Outcomes/Digits"
-  }
-
-  private val eventTypeSelector: ComboBox[String] = new ComboBox(
-    Vector("Enum", "Numeric")) {
-    value = "Enum"
-  }
-
   private val model =
-    new DLCPaneModel(resultArea,
-                     demoOracleArea,
-                     numOutcomesTF,
-                     eventTypeSelector)
+    new DLCPaneModel(resultArea, demoOracleArea)
 
   model.setUp()
 
-  private val demoOracleButton = new Button {
-    text = "Init Demo Oracle"
+  private val enumOracleButton = new Button {
+    text = "Enum Oracle"
     onAction = new EventHandler[ActionEvent] {
-      override def handle(event: ActionEvent): Unit = model.onInitOracle()
+      override def handle(event: ActionEvent): Unit = model.onInitOracle(true)
+    }
+  }
+
+  private val numericOracleButton = new Button {
+    text = "Numeric Oracle"
+    onAction = new EventHandler[ActionEvent] {
+      override def handle(event: ActionEvent): Unit = model.onInitOracle(false)
     }
   }
 
   private val oracleButtonHBox = new HBox {
-    children = Seq(numOutcomesTF, demoOracleButton, eventTypeSelector)
+    alignment = Pos.Center
+    children = Seq(enumOracleButton, numericOracleButton)
     spacing = 15
   }
 

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPaneModel.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPaneModel.scala
@@ -3,7 +3,7 @@ package org.bitcoins.gui.dlc
 import org.bitcoins.cli.CliCommand._
 import org.bitcoins.cli.{CliCommand, Config, ConsoleCli}
 import org.bitcoins.commons.jsonmodels.dlc.DLCMessage._
-import org.bitcoins.commons.jsonmodels.dlc.DLCStatus
+import org.bitcoins.commons.jsonmodels.dlc.SerializedDLCStatus
 import org.bitcoins.core.protocol.tlv.UnsignedNumericOutcome
 import org.bitcoins.crypto.{CryptoUtil, ECPrivateKey, Sha256DigestBE}
 import org.bitcoins.gui.dlc.dialog._
@@ -23,13 +23,14 @@ class DLCPaneModel(resultArea: TextArea, oracleInfoArea: TextArea) {
   val parentWindow: ObjectProperty[Window] =
     ObjectProperty[Window](null.asInstanceOf[Window])
 
-  val dlcs: ObservableBuffer[DLCStatus] = new ObservableBuffer[DLCStatus]()
+  val dlcs: ObservableBuffer[SerializedDLCStatus] =
+    new ObservableBuffer[SerializedDLCStatus]()
 
-  def getDLCs: Vector[DLCStatus] = {
+  def getDLCs: Vector[SerializedDLCStatus] = {
     ConsoleCli.exec(GetDLCs, Config.empty) match {
       case Failure(exception) => throw exception
       case Success(dlcsStr) =>
-        ujson.read(dlcsStr).arr.map(DLCStatus.fromJson).toVector
+        ujson.read(dlcsStr).arr.map(SerializedDLCStatus.fromJson).toVector
     }
   }
 
@@ -42,7 +43,7 @@ class DLCPaneModel(resultArea: TextArea, oracleInfoArea: TextArea) {
     ConsoleCli.exec(GetDLC(paramHash), Config.empty) match {
       case Failure(exception) => throw exception
       case Success(dlcStatus) =>
-        dlcs += DLCStatus.fromJson(ujson.read(dlcStatus))
+        dlcs += SerializedDLCStatus.fromJson(ujson.read(dlcStatus))
         dlcs.find(_.paramHash == paramHash).foreach(dlcs -= _)
     }
   }
@@ -200,7 +201,7 @@ class DLCPaneModel(resultArea: TextArea, oracleInfoArea: TextArea) {
     printDLCDialogResult("ExecuteDLCRefund", RefundDLCDialog)
   }
 
-  def viewDLC(status: DLCStatus): Unit = {
+  def viewDLC(status: SerializedDLCStatus): Unit = {
     updateDLCs()
     val updatedStatus = dlcs.find(_.tempContractId == status.tempContractId)
     ViewDLCDialog.showAndWait(parentWindow.value,

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPaneModel.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPaneModel.scala
@@ -78,7 +78,7 @@ class DLCPaneModel(resultArea: TextArea, oracleInfoArea: TextArea) {
     }
   }
 
-  def onInitOracle(isEnum: Boolean): Unit = {
+  def onInitContract(isEnum: Boolean): Unit = {
     val result = if (isEnum) {
       InitSingleNonceOracleDialog.showAndWait(parentWindow.value)
     } else {

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPaneModel.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPaneModel.scala
@@ -165,7 +165,7 @@ class DLCPaneModel(resultArea: TextArea, oracleInfoArea: TextArea) {
         }
 
         GlobalDLCData.lastOracleInfo = oracleInfo.hex
-        GlobalDLCData.lastContractInfo = contractInfo.hex
+        GlobalDLCData.lastContractInfo = contractInfo.toTLV.hex
 
         oracleInfoArea.text = builder.result()
       case None => ()

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPlotUtil.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPlotUtil.scala
@@ -154,7 +154,11 @@ object DLCPlotUtil {
       else ""
     }
 
-    cetPlot += plot(xs, ys, '+', name = "CETs", labels = labels)
+    cetPlot += plot(xs,
+                    ys,
+                    '+',
+                    name = s"CETs (${cets.length})",
+                    labels = labels)
     cetPlot.xlabel = "Outcome"
     cetPlot.ylabel = "Payout (sats)"
     cetPlot.legend = true

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPlotUtil.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPlotUtil.scala
@@ -126,13 +126,7 @@ object DLCPlotUtil {
       numDigits: Int,
       executedCETOpt: Option[Vector[Int]]): Figure = {
     def fromDigits(digits: Vector[Int]): Int = {
-      digits.indices
-        .foldLeft(0.0) {
-          case (numSoFar, index) =>
-            if (digits(index) == 0) numSoFar
-            else numSoFar + math.pow(base, numDigits - 1 - index)
-        }
-        .toInt
+      CETCalculator.fromDigits(digits, base, numDigits).toInt
     }
 
     val xs = cets.map(_._1).map(fromDigits)
@@ -141,10 +135,9 @@ object DLCPlotUtil {
     val figure = Figure("DLC Payout Curve")
     val cetPlot = figure.subplot(0)
 
-    // Can be made faster with binary search of xs if needed
     val canonicalCETOpt = executedCETOpt
       .flatMap { outcome =>
-        cets.map(_._1).find(outcome.startsWith(_))
+        CETCalculator.searchForPrefix(outcome, cets.map(_._1))(identity)
       }
       .map(fromDigits)
     val markedCETNumOpt = canonicalCETOpt.map(xs.indexOf)

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPlotUtil.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPlotUtil.scala
@@ -1,0 +1,164 @@
+package org.bitcoins.gui.dlc
+
+import breeze.plot.{plot, Figure}
+import org.bitcoins.commons.jsonmodels.dlc.{
+  CETCalculator,
+  OutcomeValueFunction,
+  RoundingIntervals
+}
+import org.bitcoins.core.currency.Satoshis
+
+object DLCPlotUtil {
+
+  def plotCETsWithOriginalCurve(
+      base: Int,
+      numDigits: Int,
+      function: OutcomeValueFunction,
+      totalCollateral: Satoshis,
+      rounding: RoundingIntervals): Figure = {
+    plotCETsWithOriginalCurve(base,
+                              numDigits,
+                              function,
+                              totalCollateral,
+                              rounding,
+                              executedCETOpt = None)
+  }
+
+  def plotCETsWithOriginalCurve(
+      base: Int,
+      numDigits: Int,
+      function: OutcomeValueFunction,
+      totalCollateral: Satoshis,
+      rounding: RoundingIntervals,
+      executedCET: Vector[Int]): Figure = {
+    plotCETsWithOriginalCurve(base,
+                              numDigits,
+                              function,
+                              totalCollateral,
+                              rounding,
+                              executedCETOpt = Some(executedCET))
+  }
+
+  private def plotCETsWithOriginalCurve(
+      base: Int,
+      numDigits: Int,
+      function: OutcomeValueFunction,
+      totalCollateral: Satoshis,
+      rounding: RoundingIntervals,
+      executedCETOpt: Option[Vector[Int]]): Figure = {
+    val xs = 0.until(Math.pow(base, numDigits).toInt - 1).toVector
+    val ys = xs.map(function.apply(_).toLong.toInt)
+
+    val figure = plotCETs(base,
+                          numDigits,
+                          function,
+                          totalCollateral,
+                          rounding,
+                          executedCETOpt)
+    figure.subplot(0) += plot(xs, ys, name = "Original Curve")
+    figure
+  }
+
+  def plotCETs(
+      base: Int,
+      numDigits: Int,
+      function: OutcomeValueFunction,
+      totalCollateral: Satoshis,
+      rounding: RoundingIntervals): Figure = {
+    plotCETs(base,
+             numDigits,
+             function,
+             totalCollateral,
+             rounding,
+             executedCETOpt = None)
+  }
+
+  def plotCETs(
+      base: Int,
+      numDigits: Int,
+      function: OutcomeValueFunction,
+      totalCollateral: Satoshis,
+      rounding: RoundingIntervals,
+      executedDLC: Vector[Int]): Figure = {
+    plotCETs(base,
+             numDigits,
+             function,
+             totalCollateral,
+             rounding,
+             executedCETOpt = Some(executedDLC))
+  }
+
+  private def plotCETs(
+      base: Int,
+      numDigits: Int,
+      function: OutcomeValueFunction,
+      totalCollateral: Satoshis,
+      rounding: RoundingIntervals,
+      executedCETOpt: Option[Vector[Int]]): Figure = {
+    plotCETs(CETCalculator.computeCETs(base,
+                                       numDigits,
+                                       function,
+                                       totalCollateral,
+                                       rounding),
+             base,
+             numDigits,
+             executedCETOpt)
+  }
+
+  def plotCETs(
+      cets: Vector[(Vector[Int], Satoshis)],
+      base: Int,
+      numDigits: Int): Figure = {
+    plotCETs(cets, base, numDigits, executedCETOpt = None)
+  }
+
+  def plotCETs(
+      cets: Vector[(Vector[Int], Satoshis)],
+      base: Int,
+      numDigits: Int,
+      executedCET: Vector[Int]): Figure = {
+    plotCETs(cets, base, numDigits, executedCETOpt = Some(executedCET))
+  }
+
+  private def plotCETs(
+      cets: Vector[(Vector[Int], Satoshis)],
+      base: Int,
+      numDigits: Int,
+      executedCETOpt: Option[Vector[Int]]): Figure = {
+    def fromDigits(digits: Vector[Int]): Int = {
+      digits.indices
+        .foldLeft(0.0) {
+          case (numSoFar, index) =>
+            if (digits(index) == 0) numSoFar
+            else numSoFar + math.pow(base, numDigits - 1 - index)
+        }
+        .toInt
+    }
+
+    val xs = cets.map(_._1).map(fromDigits)
+    val ys = cets.map(_._2.toLong.toInt)
+
+    val figure = Figure("DLC Payout Curve")
+    val cetPlot = figure.subplot(0)
+
+    // Can be made faster with binary search of xs if needed
+    val canonicalCETOpt = executedCETOpt
+      .flatMap { outcome =>
+        cets.map(_._1).find(outcome.startsWith(_))
+      }
+      .map(fromDigits)
+    val markedCETNumOpt = canonicalCETOpt.map(xs.indexOf)
+    val labels = { x: Int =>
+      if (markedCETNumOpt.contains(x))
+        s"Executed CET(${canonicalCETOpt.get}, ${ys(x)})"
+      else ""
+    }
+
+    cetPlot += plot(xs, ys, '+', name = "CETs", labels = labels)
+    cetPlot.xlabel = "Outcome"
+    cetPlot.ylabel = "Payout (sats)"
+    cetPlot.legend = true
+
+    figure
+  }
+}

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCTableView.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCTableView.scala
@@ -1,19 +1,18 @@
 package org.bitcoins.gui.dlc
 
-import org.bitcoins.commons.jsonmodels.dlc.DLCStatus.Offered
 import org.bitcoins.commons.jsonmodels.dlc.{
-  AcceptedDLCStatus,
-  DLCStatus,
-  SignedDLCStatus
+  AcceptedSerializedDLCStatus,
+  SerializedDLCStatus
 }
+import org.bitcoins.commons.jsonmodels.dlc.SerializedDLCStatus._
 import scalafx.beans.property.StringProperty
 import scalafx.geometry.Insets
 import scalafx.scene.control.{ContextMenu, MenuItem, TableColumn, TableView}
 
 class DLCTableView(model: DLCPaneModel) {
 
-  val tableView: TableView[DLCStatus] = {
-    val paramHashCol = new TableColumn[DLCStatus, String] {
+  val tableView: TableView[SerializedDLCStatus] = {
+    val paramHashCol = new TableColumn[SerializedDLCStatus, String] {
       text = "Temp Contract Id"
       prefWidth = 150
       cellValueFactory = { status =>
@@ -23,14 +22,13 @@ class DLCTableView(model: DLCPaneModel) {
       }
     }
 
-    val contractIdCol = new TableColumn[DLCStatus, String] {
+    val contractIdCol = new TableColumn[SerializedDLCStatus, String] {
       text = "Contract Id"
       prefWidth = 150
       cellValueFactory = { status =>
         val contractIdStr = status.value match {
-          case _: DLCStatus.Offered | _: DLCStatus.Accepted =>
-            ""
-          case signed: SignedDLCStatus =>
+          case _: SerializedOffered => ""
+          case signed: AcceptedSerializedDLCStatus =>
             signed.contractId.toHex
         }
 
@@ -38,7 +36,7 @@ class DLCTableView(model: DLCPaneModel) {
       }
     }
 
-    val statusCol = new TableColumn[DLCStatus, String] {
+    val statusCol = new TableColumn[SerializedDLCStatus, String] {
       text = "Status"
       prefWidth = 150
       cellValueFactory = { status =>
@@ -46,7 +44,7 @@ class DLCTableView(model: DLCPaneModel) {
       }
     }
 
-    val initiatorCol = new TableColumn[DLCStatus, String] {
+    val initiatorCol = new TableColumn[SerializedDLCStatus, String] {
       text = "Initiator"
       prefWidth = 80
       cellValueFactory = { status =>
@@ -59,55 +57,47 @@ class DLCTableView(model: DLCPaneModel) {
       }
     }
 
-    val collateralCol = new TableColumn[DLCStatus, String] {
+    val collateralCol = new TableColumn[SerializedDLCStatus, String] {
       text = "Collateral"
       prefWidth = 110
       cellValueFactory = { status =>
-        val num = if (status.value.isInitiator) {
-          status.value.offer.totalCollateral.toLong
-        } else {
-          status.value match {
-            case _: Offered => ""
-            case accepted: AcceptedDLCStatus =>
-              accepted.accept.totalCollateral.toLong
-          }
-        }
-        new StringProperty(status, "Collateral", num.toString)
+        new StringProperty(status,
+                           "Collateral",
+                           status.value.localCollateral.toString)
       }
     }
 
-    val oracleCol = new TableColumn[DLCStatus, String] {
+    val oracleCol = new TableColumn[SerializedDLCStatus, String] {
       text = "Oracle"
       prefWidth = 150
       cellValueFactory = { status =>
-        new StringProperty(status,
-                           "Oracle",
-                           status.value.offer.oracleInfo.pubKey.hex)
+        new StringProperty(status, "Oracle", status.value.oracleInfo.pubKey.hex)
       }
     }
 
-    val eventCol = new TableColumn[DLCStatus, String] {
+    val eventCol = new TableColumn[SerializedDLCStatus, String] {
       text = "Event"
       prefWidth = 150
       cellValueFactory = { status =>
-        new StringProperty(status,
-                           "Event",
-                           status.value.offer.oracleInfo.nonces.head.hex)
+        new StringProperty(
+          status,
+          "Event",
+          status.value.oracleInfo.nonces.map(_.hex).mkString(""))
       }
     }
 
-    val contractMaturityCol = new TableColumn[DLCStatus, String] {
+    val contractMaturityCol = new TableColumn[SerializedDLCStatus, String] {
       text = "Contract Mat."
       prefWidth = 110
       cellValueFactory = { status =>
         new StringProperty(
           status,
           "Contract Maturity",
-          status.value.offer.timeouts.contractMaturity.toUInt32.toLong.toString)
+          status.value.timeouts.contractMaturity.toUInt32.toLong.toString)
       }
     }
 
-    new TableView[DLCStatus](model.dlcs) {
+    new TableView[SerializedDLCStatus](model.dlcs) {
       columns ++= Seq(paramHashCol,
                       contractIdCol,
                       statusCol,

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/AcceptDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/AcceptDLCDialog.scala
@@ -7,10 +7,15 @@ import scalafx.scene.Node
 object AcceptDLCDialog
     extends DLCDialog[AcceptDLCCliCommand](
       "Accept DLC Offer",
-      "Enter DLC offer to accept or open from file",
-      Vector(DLCDialog.dlcOfferStr -> DLCDialog.textArea(),
-             DLCDialog.dlcOfferFileStr -> DLCDialog.fileChooserButton(file =>
-               DLCDialog.offerDLCFile = Some(file))),
+      "Enter DLC Offer to accept or open from file",
+      Vector(
+        DLCDialog.dlcOfferStr -> DLCDialog.textArea(),
+        DLCDialog.dlcOfferFileStr -> DLCDialog.fileChooserButton(file => {
+          DLCDialog.offerDLCFile = Some(file)
+          DLCDialog.offerFileChosenLabel.text = file.toString
+        }),
+        DLCDialog.fileChosenStr -> DLCDialog.offerFileChosenLabel
+      ),
       Vector(DLCDialog.dlcOfferStr, DLCDialog.dlcOfferFileStr)) {
   import DLCDialog._
 
@@ -19,6 +24,7 @@ object AcceptDLCDialog
     offerDLCFile match {
       case Some(file) =>
         offerDLCFile = None // reset
+        offerFileChosenLabel.text = "" // reset
         AcceptDLCOfferFromFile(file.toPath)
       case None =>
         val offerHex = readStringFromNode(inputs(dlcOfferStr))

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/AcceptDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/AcceptDLCDialog.scala
@@ -12,7 +12,7 @@ object AcceptDLCDialog
 
   override def constructFromInput(
       inputs: Map[String, String]): AcceptDLCOffer = {
-    val offer = LnMessageFactory(DLCOfferTLV).fromHex(dlcOfferStr)
+    val offer = LnMessageFactory(DLCOfferTLV).fromHex(inputs(dlcOfferStr))
 
     AcceptDLCOffer(offer)
   }

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/AcceptDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/AcceptDLCDialog.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.gui.dlc.dialog
 
 import org.bitcoins.cli.CliCommand.AcceptDLCOffer
-import org.bitcoins.commons.jsonmodels.dlc.DLCMessage.DLCOffer
+import org.bitcoins.core.protocol.tlv.DLCOfferTLV
 
 object AcceptDLCDialog
     extends DLCDialog[AcceptDLCOffer](
@@ -12,7 +12,7 @@ object AcceptDLCDialog
 
   override def constructFromInput(
       inputs: Map[String, String]): AcceptDLCOffer = {
-    val offer = DLCOffer.fromJson(ujson.read(inputs(dlcOfferStr)))
+    val offer = DLCOfferTLV(dlcOfferStr)
     AcceptDLCOffer(offer)
   }
 }

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/AcceptDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/AcceptDLCDialog.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.gui.dlc.dialog
 
 import org.bitcoins.cli.CliCommand.AcceptDLCOffer
-import org.bitcoins.core.protocol.tlv.DLCOfferTLV
+import org.bitcoins.core.protocol.tlv._
 
 object AcceptDLCDialog
     extends DLCDialog[AcceptDLCOffer](
@@ -12,7 +12,8 @@ object AcceptDLCDialog
 
   override def constructFromInput(
       inputs: Map[String, String]): AcceptDLCOffer = {
-    val offer = DLCOfferTLV(dlcOfferStr)
+    val offer = LnMessageFactory(DLCOfferTLV).fromHex(dlcOfferStr)
+
     AcceptDLCOffer(offer)
   }
 }

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/AddSigsDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/AddSigsDLCDialog.scala
@@ -5,14 +5,21 @@ import org.bitcoins.core.protocol.tlv._
 import scalafx.scene.Node
 
 object AddSigsDLCDialog
-    extends DLCDialog[AddDLCSigsCliCommand](
-      "Add DLC Signatures",
-      "Enter DLC signatures message",
-      Vector(DLCDialog.dlcSigStr -> DLCDialog.textArea(),
-             DLCDialog.dlcSignFileStr ->
-               DLCDialog.fileChooserButton(file =>
-                 DLCDialog.signDLCFile = Some(file))),
-      Vector(DLCDialog.dlcSigStr, DLCDialog.dlcSignFileStr)) {
+    extends DLCDialog[AddDLCSigsCliCommand]("Add DLC Signatures",
+                                            "Enter DLC signatures message",
+                                            Vector(
+                                              DLCDialog.dlcSigStr -> DLCDialog
+                                                .textArea(),
+                                              DLCDialog.dlcSignFileStr ->
+                                                DLCDialog.fileChooserButton { file =>
+                                                  DLCDialog.signDLCFile =
+                                                    Some(file)
+                                                  DLCDialog.signFileChosenLabel.text =
+                                                    file.toString
+                                                }
+                                            ),
+                                            Vector(DLCDialog.dlcSigStr,
+                                                   DLCDialog.dlcSignFileStr)) {
 
   import DLCDialog._
 
@@ -21,6 +28,7 @@ object AddSigsDLCDialog
     signDLCFile match {
       case Some(file) =>
         signDLCFile = None // reset
+        signFileChosenLabel.text = "" // reset
         AddDLCSigsFromFile(file.toPath)
       case None =>
         val signHex = readStringFromNode(inputs(dlcSigStr))

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/AddSigsDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/AddSigsDLCDialog.scala
@@ -1,19 +1,33 @@
 package org.bitcoins.gui.dlc.dialog
 
-import org.bitcoins.cli.CliCommand.AddDLCSigs
+import org.bitcoins.cli.CliCommand._
 import org.bitcoins.core.protocol.tlv._
+import scalafx.scene.Node
 
 object AddSigsDLCDialog
-    extends DLCDialog[AddDLCSigs](
-      "Sign DLC",
+    extends DLCDialog[AddDLCSigsCliCommand](
+      "Add DLC Signatures",
       "Enter DLC signatures message",
-      Vector(DLCDialog.dlcSigStr -> DLCDialog.textArea())) {
+      Vector(DLCDialog.dlcSigStr -> DLCDialog.textArea(),
+             DLCDialog.dlcSignFileStr ->
+               DLCDialog.fileChooserButton(file =>
+                 DLCDialog.signDLCFile = Some(file))),
+      Vector(DLCDialog.dlcSigStr, DLCDialog.dlcSignFileStr)) {
 
   import DLCDialog._
 
-  override def constructFromInput(inputs: Map[String, String]): AddDLCSigs = {
-    val sign = LnMessageFactory(DLCSignTLV).fromHex(inputs(dlcSigStr))
+  override def constructFromInput(
+      inputs: Map[String, Node]): AddDLCSigsCliCommand = {
+    signDLCFile match {
+      case Some(file) =>
+        signDLCFile = None // reset
+        AddDLCSigsFromFile(file.toPath)
+      case None =>
+        val signHex = readStringFromNode(inputs(dlcSigStr))
 
-    AddDLCSigs(sign)
+        val sign = LnMessageFactory(DLCSignTLV).fromHex(signHex)
+
+        AddDLCSigs(sign)
+    }
   }
 }

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/AddSigsDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/AddSigsDLCDialog.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.gui.dlc.dialog
 
 import org.bitcoins.cli.CliCommand.AddDLCSigs
-import org.bitcoins.commons.jsonmodels.dlc.DLCMessage.DLCSign
+import org.bitcoins.core.protocol.tlv.DLCSignTLV
 
 object AddSigsDLCDialog
     extends DLCDialog[AddDLCSigs](
@@ -12,7 +12,7 @@ object AddSigsDLCDialog
   import DLCDialog._
 
   override def constructFromInput(inputs: Map[String, String]): AddDLCSigs = {
-    val sign = DLCSign.fromJson(ujson.read(inputs(dlcSigStr)))
+    val sign = DLCSignTLV(dlcSigStr)
     AddDLCSigs(sign)
   }
 }

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/AddSigsDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/AddSigsDLCDialog.scala
@@ -12,7 +12,7 @@ object AddSigsDLCDialog
   import DLCDialog._
 
   override def constructFromInput(inputs: Map[String, String]): AddDLCSigs = {
-    val sign = LnMessageFactory(DLCSignTLV).fromHex(dlcSigStr)
+    val sign = LnMessageFactory(DLCSignTLV).fromHex(inputs(dlcSigStr))
 
     AddDLCSigs(sign)
   }

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/AddSigsDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/AddSigsDLCDialog.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.gui.dlc.dialog
 
 import org.bitcoins.cli.CliCommand.AddDLCSigs
-import org.bitcoins.core.protocol.tlv.DLCSignTLV
+import org.bitcoins.core.protocol.tlv._
 
 object AddSigsDLCDialog
     extends DLCDialog[AddDLCSigs](
@@ -12,7 +12,8 @@ object AddSigsDLCDialog
   import DLCDialog._
 
   override def constructFromInput(inputs: Map[String, String]): AddDLCSigs = {
-    val sign = DLCSignTLV(dlcSigStr)
+    val sign = LnMessageFactory(DLCSignTLV).fromHex(dlcSigStr)
+
     AddDLCSigs(sign)
   }
 }

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/DLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/DLCDialog.scala
@@ -1,27 +1,41 @@
 package org.bitcoins.gui.dlc.dialog
 
+import java.io.File
+
 import org.bitcoins.cli.CliCommand
 import org.bitcoins.gui.GlobalData
 import org.bitcoins.gui.dlc.GlobalDLCData
 import scalafx.Includes._
 import scalafx.application.Platform
+import scalafx.beans.property.BooleanProperty
 import scalafx.geometry.Insets
+import scalafx.scene.Node
 import scalafx.scene.control._
 import scalafx.scene.layout.GridPane
-import scalafx.stage.Window
+import scalafx.stage.{FileChooser, Window}
+
+import scala.util.Properties
 
 abstract class DLCDialog[T <: CliCommand](
     dialogTitle: String,
     header: String,
     fields: Vector[
-      (String, TextInputControl)
+      (String, Node)
     ], // Vector instead of Map to keep order
     optionalFields: Vector[String] = Vector.empty) {
 
   private def readCachedValue(key: String, value: String): Unit = {
     fields
       .find(_._1 == key)
-      .foreach(_._2.text = value)
+      .foreach {
+        _._2 match {
+          case textInput: TextInputControl =>
+            textInput.text = value
+          case node: Node =>
+            throw new IllegalArgumentException(
+              s"Control at $key is not a text input control, got $node")
+        }
+      }
   }
 
   readCachedValue(DLCDialog.dlcContractIdStr, GlobalDLCData.lastContractId)
@@ -38,7 +52,16 @@ abstract class DLCDialog[T <: CliCommand](
       .foreach(pair => setter(pair._2))
   }
 
-  def constructFromInput(inputs: Map[String, String]): T
+  protected def readStringFromNode(node: Node): String = {
+    node match {
+      case textInputControl: TextInputControl =>
+        textInputControl.text.value
+      case node: Node =>
+        throw new RuntimeException(s"Got unexpected Node, got $node")
+    }
+  }
+
+  def constructFromInput(inputs: Map[String, Node]): T
 
   def showAndWait(parentWindow: Window): Option[T] = {
     val dialog = new Dialog[Option[T]]() {
@@ -56,9 +79,9 @@ abstract class DLCDialog[T <: CliCommand](
       padding = Insets(20, 100, 10, 10)
 
       var nextRow: Int = 0
-      def addRow(label: String, textField: TextInputControl): Unit = {
+      def addRow(label: String, node: Node): Unit = {
         add(new Label(label), 0, nextRow)
-        add(textField, 1, nextRow)
+        add(node, 1, nextRow)
         nextRow += 1
       }
 
@@ -69,12 +92,20 @@ abstract class DLCDialog[T <: CliCommand](
 
     // Enable/Disable OK button depending on whether all data was entered.
     val okButton = dialog.dialogPane().lookupButton(ButtonType.OK)
-    val requiredFields =
-      fields.filterNot(field => optionalFields.contains(field._1))
+    val requiredTextFields =
+      fields.filterNot(field => optionalFields.contains(field._1)).collect {
+        case (_: String, textInputControl: TextInputControl) => textInputControl
+      }
     // Simple validation that sufficient data was entered
-    okButton.disable <== requiredFields
-      .map(_._2.text.isEmpty)
-      .reduce(_ || _)
+    okButton.disable <== {
+      val bools = requiredTextFields
+        .map(_.text.isEmpty)
+
+      // Need to do this because foldLeft doesn't work nicely
+      if (bools.isEmpty) {
+        BooleanProperty(false).delegate
+      } else bools.reduce(_ || _).delegate
+    }
 
     // Request focus on the first field by default.
     Platform.runLater(fields.head._2.requestFocus())
@@ -82,22 +113,24 @@ abstract class DLCDialog[T <: CliCommand](
     // When the OK button is clicked, convert the result to a T.
     dialog.resultConverter = dialogButton =>
       if (dialogButton == ButtonType.OK) {
-        val inputs = fields.map { case (key, input) => (key, input.text()) }
+        val textInputs = fields.collect {
+          case (key: String, input: TextInputControl) => (key, input.text())
+        }
 
         writeCachedValue(DLCDialog.dlcContractIdStr,
-                         inputs,
+                         textInputs,
                          GlobalDLCData.lastContractId = _)
         writeCachedValue(DLCDialog.dlcOracleSigStr,
-                         inputs,
+                         textInputs,
                          GlobalDLCData.lastOracleSig = _)
         writeCachedValue(DLCDialog.oracleInfoStr,
-                         inputs,
+                         textInputs,
                          GlobalDLCData.lastOracleInfo = _)
         writeCachedValue(DLCDialog.contractInfoStr,
-                         inputs,
+                         textInputs,
                          GlobalDLCData.lastContractInfo = _)
 
-        Some(constructFromInput(inputs.toMap))
+        Some(constructFromInput(fields.toMap))
       } else None
 
     val result = dialog.showAndWait()
@@ -116,6 +149,27 @@ object DLCDialog {
       wrapText = true
     }
   }
+
+  def fileChooserButton[T](handleFile: File => T): Node = {
+    new Button("Browse...") {
+      onAction = _ => {
+        val fileChooser = new FileChooser() {
+          initialDirectory = new File(Properties.userHome)
+        }
+
+        val selectedFile = fileChooser.showOpenDialog(null)
+
+        if (selectedFile != null) {
+          handleFile(selectedFile)
+          ()
+        }
+      }
+    }
+  }
+
+  var offerDLCFile: Option[File] = None
+  var acceptDLCFile: Option[File] = None
+  var signDLCFile: Option[File] = None
 
   val oracleInfoStr = "Oracle Info"
   val contractInfoStr = "Contract Info"
@@ -143,10 +197,13 @@ object DLCDialog {
     }.toVector
 
   val dlcOfferStr = "DLC Offer"
+  val dlcOfferFileStr = "Open Offer from File"
 
   val dlcAcceptStr = "DLC Accept Message"
+  val dlcAcceptFileStr = "Open Accept from File"
 
   val dlcSigStr = "DLC Signatures"
+  val dlcSignFileStr = "Open Sign from File"
 
   val dlcContractIdStr = "Contract ID"
 

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/DLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/DLCDialog.scala
@@ -171,12 +171,18 @@ object DLCDialog {
   var acceptDLCFile: Option[File] = None
   var signDLCFile: Option[File] = None
 
+  val offerFileChosenLabel = new Label("")
+  val acceptFileChosenLabel = new Label("")
+  val signFileChosenLabel = new Label("")
+
   val oracleInfoStr = "Oracle Info"
   val contractInfoStr = "Contract Info"
   val collateralStr = "Collateral"
   val feeRateStr = "Fee Rate"
   val locktimeStr = "Locktime"
   val refundLocktimeStr = "Refund Locktime"
+
+  val fileChosenStr = ""
 
   val allOfferFields: Map[String, String] = Map[String, String](
     oracleInfoStr -> "",

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/ExecuteDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/ExecuteDLCDialog.scala
@@ -8,16 +8,21 @@ import scodec.bits.ByteVector
 object ExecuteDLCDialog
     extends DLCDialog[ExecuteDLC](
       "DLC Close",
-      "Enter DLC closing info",
+      "Enter DLC execution info",
       Vector(DLCDialog.dlcContractIdStr -> new TextField(),
              DLCDialog.dlcOracleSigStr -> new TextField())) {
   import DLCDialog._
 
   override def constructFromInput(inputs: Map[String, String]): ExecuteDLC = {
     val contractId = inputs(dlcContractIdStr)
-    val oracleSig = SchnorrDigitalSignature(inputs(dlcOracleSigStr))
+    val oracleSigsStr = inputs(dlcOracleSigStr)
+
+    val oracleSigs = oracleSigsStr.split(",").map { str =>
+      SchnorrDigitalSignature.fromHex(str.trim)
+    }
+
     ExecuteDLC(ByteVector.fromValidHex(contractId),
-               Vector(oracleSig),
+               oracleSigs.toVector,
                noBroadcast = false)
   }
 }

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/ExecuteDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/ExecuteDLCDialog.scala
@@ -1,10 +1,11 @@
 package org.bitcoins.gui.dlc.dialog
 
 import org.bitcoins.cli.CliCommand.ExecuteDLC
-import org.bitcoins.crypto.{SchnorrDigitalSignature, Sha256Digest}
+import org.bitcoins.crypto.SchnorrDigitalSignature
 import scalafx.scene.control.TextField
+import scodec.bits.ByteVector
 
-object ForceCloseDLCDialog
+object ExecuteDLCDialog
     extends DLCDialog[ExecuteDLC](
       "DLC Close",
       "Enter DLC closing info",
@@ -13,8 +14,10 @@ object ForceCloseDLCDialog
   import DLCDialog._
 
   override def constructFromInput(inputs: Map[String, String]): ExecuteDLC = {
-    val eventId = Sha256Digest(inputs(dlcContractIdStr))
+    val contractId = inputs(dlcContractIdStr)
     val oracleSig = SchnorrDigitalSignature(inputs(dlcOracleSigStr))
-    ExecuteDLC(eventId, oracleSig, noBroadcast = false)
+    ExecuteDLC(ByteVector.fromValidHex(contractId),
+               Vector(oracleSig),
+               noBroadcast = false)
   }
 }

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/ExecuteDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/ExecuteDLCDialog.scala
@@ -2,6 +2,7 @@ package org.bitcoins.gui.dlc.dialog
 
 import org.bitcoins.cli.CliCommand.ExecuteDLC
 import org.bitcoins.crypto.SchnorrDigitalSignature
+import scalafx.scene.Node
 import scalafx.scene.control.TextField
 import scodec.bits.ByteVector
 
@@ -13,9 +14,9 @@ object ExecuteDLCDialog
              DLCDialog.dlcOracleSigStr -> new TextField())) {
   import DLCDialog._
 
-  override def constructFromInput(inputs: Map[String, String]): ExecuteDLC = {
-    val contractId = inputs(dlcContractIdStr)
-    val oracleSigsStr = inputs(dlcOracleSigStr)
+  override def constructFromInput(inputs: Map[String, Node]): ExecuteDLC = {
+    val contractId = readStringFromNode(inputs(dlcContractIdStr))
+    val oracleSigsStr = readStringFromNode(inputs(dlcOracleSigStr))
 
     val oracleSigs = oracleSigsStr.split(",").map { str =>
       SchnorrDigitalSignature.fromHex(str.trim)

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/GetFundingDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/GetFundingDLCDialog.scala
@@ -1,6 +1,7 @@
 package org.bitcoins.gui.dlc.dialog
 
 import org.bitcoins.cli.CliCommand.BroadcastDLCFundingTx
+import scalafx.scene.Node
 import scalafx.scene.control.TextField
 import scodec.bits.ByteVector
 
@@ -12,8 +13,10 @@ object GetFundingDLCDialog
   import DLCDialog._
 
   override def constructFromInput(
-      inputs: Map[String, String]): BroadcastDLCFundingTx = {
-    val contractId = ByteVector.fromValidHex(inputs(dlcContractIdStr))
+      inputs: Map[String, Node]): BroadcastDLCFundingTx = {
+    val hex = readStringFromNode(inputs(dlcContractIdStr))
+
+    val contractId = ByteVector.fromValidHex(hex)
     BroadcastDLCFundingTx(contractId)
   }
 }

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/GetFundingDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/GetFundingDLCDialog.scala
@@ -1,19 +1,19 @@
 package org.bitcoins.gui.dlc.dialog
 
 import org.bitcoins.cli.CliCommand.BroadcastDLCFundingTx
-import org.bitcoins.crypto.Sha256Digest
 import scalafx.scene.control.TextField
+import scodec.bits.ByteVector
 
 object GetFundingDLCDialog
     extends DLCDialog[BroadcastDLCFundingTx](
       "DLC Funding Transaction",
-      "Enter DLC event ID",
+      "Enter DLC contract ID",
       Vector(DLCDialog.dlcContractIdStr -> new TextField())) {
   import DLCDialog._
 
   override def constructFromInput(
       inputs: Map[String, String]): BroadcastDLCFundingTx = {
-    val eventId = Sha256Digest(inputs(dlcContractIdStr))
-    BroadcastDLCFundingTx(eventId)
+    val contractId = ByteVector.fromValidHex(inputs(dlcContractIdStr))
+    BroadcastDLCFundingTx(contractId)
   }
 }

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/InitEnumContractDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/InitEnumContractDialog.scala
@@ -13,7 +13,7 @@ import scalafx.stage.Window
 
 import scala.collection._
 
-object InitSingleNonceOracleDialog {
+object InitEnumContractDialog {
 
   def showAndWait(parentWindow: Window): Option[SingleNonceContractInfo] = {
     val dialog =

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/InitMultiNonceOracleDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/InitMultiNonceOracleDialog.scala
@@ -1,0 +1,173 @@
+package org.bitcoins.gui.dlc.dialog
+
+import org.bitcoins.commons.jsonmodels.dlc.DLCMessage.MultiNonceContractInfo
+import org.bitcoins.commons.jsonmodels.dlc.{
+  OutcomeValueFunction,
+  OutcomeValuePoint
+}
+import org.bitcoins.core.currency.Satoshis
+import org.bitcoins.gui.GlobalData
+import scalafx.Includes._
+import scalafx.application.Platform
+import scalafx.geometry.{Insets, Pos}
+import scalafx.scene.Node
+import scalafx.scene.control._
+import scalafx.scene.layout.{GridPane, HBox, VBox}
+import scalafx.stage.Window
+
+object InitMultiNonceOracleDialog {
+
+  private def setNumericInput(textField: TextField): Unit = {
+    textField.text.addListener {
+      (
+          _: javafx.beans.value.ObservableValue[_ <: String],
+          _: String,
+          newVal: String) =>
+        if (!newVal.matches("\\d*"))
+          textField.setText(newVal.replaceAll("[^\\d]", ""))
+    }
+
+  }
+
+  def showAndWait(
+      parentWindow: Window,
+      numDigits: Int): Option[MultiNonceContractInfo] = {
+    val dialog =
+      new Dialog[Option[MultiNonceContractInfo]]() {
+        initOwner(parentWindow)
+        title = "Initialize Demo Oracle"
+        headerText = "Enter contract interpolation points"
+      }
+
+    dialog.dialogPane().buttonTypes = Seq(ButtonType.OK, ButtonType.Cancel)
+    dialog.dialogPane().stylesheets = GlobalData.currentStyleSheets
+    dialog.resizable = true
+
+    val baseTF = new TextField() {
+      text = "2"
+    }
+
+    val totalCollateralTF = new TextField() {
+      promptText = "Satoshis"
+    }
+    setNumericInput(baseTF)
+    setNumericInput(totalCollateralTF)
+
+    val pointMap: scala.collection.mutable.Map[
+      Int,
+      (TextField, TextField, CheckBox)] =
+      scala.collection.mutable.Map.empty
+
+    var nextPointRow: Int = 2
+    val pointGrid: GridPane = new GridPane {
+      alignment = Pos.Center
+      padding = Insets(top = 10, right = 10, bottom = 10, left = 10)
+      hgap = 5
+      vgap = 5
+
+      add(new Label("Outcome"), 0, 0)
+      add(new Label("Payout"), 1, 0)
+      add(new Label("Endpoint"), 2, 0)
+    }
+
+    def addPointRow(): Unit = {
+
+      val xTF = new TextField() {
+        promptText = "X Point"
+      }
+      val yTF = new TextField() {
+        promptText = "Y Point"
+      }
+      val endPointBox = new CheckBox() {
+        selected = true
+      }
+      setNumericInput(xTF)
+      setNumericInput(yTF)
+
+      val row = nextPointRow
+      pointMap.addOne((row, (xTF, yTF, endPointBox)))
+
+      pointGrid.add(xTF, 0, row)
+      pointGrid.add(yTF, 1, row)
+      pointGrid.add(new Label("Endpoint:"), 2, row)
+      pointGrid.add(endPointBox, 3, row)
+
+      nextPointRow += 1
+      dialog.dialogPane().getScene.getWindow.sizeToScene()
+    }
+
+    addPointRow()
+    addPointRow()
+
+    val addPointButton: Button = new Button("+") {
+      onAction = _ => addPointRow()
+    }
+
+    dialog.dialogPane().content = new VBox() {
+      padding = Insets(20, 10, 10, 10)
+      spacing = 10
+      alignment = Pos.Center
+
+      val eventDataGrid: GridPane = new GridPane {
+        padding = Insets(top = 10, right = 10, bottom = 10, left = 10)
+        hgap = 5
+        vgap = 5
+
+        add(new Label("Base"), 0, 0)
+        add(baseTF, 1, 0)
+        add(new Label("Total Collateral"), 0, 1)
+        add(totalCollateralTF, 1, 1)
+      }
+
+      val outcomes: Node = new VBox {
+        alignment = Pos.Center
+
+        val label: HBox = new HBox {
+          alignment = Pos.Center
+          spacing = 10
+          children = Vector(new Label("Points"), addPointButton)
+        }
+        children = Vector(label, pointGrid)
+      }
+
+      children = Vector(eventDataGrid, new Separator(), outcomes)
+    }
+    // Enable/Disable OK button depending on whether all data was entered.
+    val okButton = dialog.dialogPane().lookupButton(ButtonType.OK)
+    // Simple validation that sufficient data was entered
+    okButton.disable <== baseTF.text.isEmpty || totalCollateralTF.text.isEmpty
+
+    Platform.runLater(totalCollateralTF.requestFocus())
+
+    // When the OK button is clicked, convert the result to a CreateDLCOffer.
+    dialog.resultConverter = dialogButton =>
+      if (dialogButton == ButtonType.OK) {
+        val base = baseTF.text.value.toInt
+        val totalCollateral = Satoshis(totalCollateralTF.text.value.toLong)
+
+        val points = pointMap.values.toVector
+        val outcomesValuePoints = points.flatMap {
+          case (xTF, yTF, checkBox) =>
+            if (xTF.text.value.nonEmpty && yTF.text.value.nonEmpty) {
+              val x = xTF.text.value.toLong
+              val y = yTF.text.value.toLong
+              Some(OutcomeValuePoint(x, Satoshis(y), checkBox.selected.value))
+            } else {
+              None
+            }
+        }
+
+        val func = OutcomeValueFunction(outcomesValuePoints)
+        val contractInfo =
+          MultiNonceContractInfo(func, base, numDigits, totalCollateral)
+
+        Some(contractInfo)
+      } else None
+
+    dialog.showAndWait() match {
+      case Some(Some(contractInfo: MultiNonceContractInfo)) =>
+        Some(contractInfo)
+      case Some(_) | None => None
+    }
+  }
+}

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/InitMultiNonceOracleDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/InitMultiNonceOracleDialog.scala
@@ -7,6 +7,7 @@ import org.bitcoins.commons.jsonmodels.dlc.{
 }
 import org.bitcoins.core.currency.Satoshis
 import org.bitcoins.gui.GlobalData
+import org.bitcoins.gui.util.GUIUtil.setNumericInput
 import scalafx.Includes._
 import scalafx.application.Platform
 import scalafx.geometry.{Insets, Pos}
@@ -17,21 +18,7 @@ import scalafx.stage.Window
 
 object InitMultiNonceOracleDialog {
 
-  private def setNumericInput(textField: TextField): Unit = {
-    textField.text.addListener {
-      (
-          _: javafx.beans.value.ObservableValue[_ <: String],
-          _: String,
-          newVal: String) =>
-        if (!newVal.matches("\\d*"))
-          textField.setText(newVal.replaceAll("[^\\d]", ""))
-    }
-
-  }
-
-  def showAndWait(
-      parentWindow: Window,
-      numDigits: Int): Option[MultiNonceContractInfo] = {
+  def showAndWait(parentWindow: Window): Option[MultiNonceContractInfo] = {
     val dialog =
       new Dialog[Option[MultiNonceContractInfo]]() {
         initOwner(parentWindow)
@@ -46,6 +33,8 @@ object InitMultiNonceOracleDialog {
     val baseTF = new TextField() {
       text = "2"
     }
+
+    val numDigitsTF = new TextField()
 
     val totalCollateralTF = new TextField() {
       promptText = "Satoshis"
@@ -73,10 +62,10 @@ object InitMultiNonceOracleDialog {
     def addPointRow(): Unit = {
 
       val xTF = new TextField() {
-        promptText = "X Point"
+        promptText = "Outcome (base 10)"
       }
       val yTF = new TextField() {
-        promptText = "Y Point"
+        promptText = "Satoshis"
       }
       val endPointBox = new CheckBox() {
         selected = true
@@ -115,8 +104,10 @@ object InitMultiNonceOracleDialog {
 
         add(new Label("Base"), 0, 0)
         add(baseTF, 1, 0)
-        add(new Label("Total Collateral"), 0, 1)
-        add(totalCollateralTF, 1, 1)
+        add(new Label("Num Digits"), 0, 1)
+        add(numDigitsTF, 1, 1)
+        add(new Label("Total Collateral"), 0, 2)
+        add(totalCollateralTF, 1, 2)
       }
 
       val outcomes: Node = new VBox {
@@ -137,12 +128,13 @@ object InitMultiNonceOracleDialog {
     // Simple validation that sufficient data was entered
     okButton.disable <== baseTF.text.isEmpty || totalCollateralTF.text.isEmpty
 
-    Platform.runLater(totalCollateralTF.requestFocus())
+    Platform.runLater(numDigitsTF.requestFocus())
 
     // When the OK button is clicked, convert the result to a CreateDLCOffer.
     dialog.resultConverter = dialogButton =>
       if (dialogButton == ButtonType.OK) {
         val base = baseTF.text.value.toInt
+        val numDigits = numDigitsTF.text.value.toInt
         val totalCollateral = Satoshis(totalCollateralTF.text.value.toLong)
 
         val points = pointMap.values.toVector

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/InitMultiNonceOracleDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/InitMultiNonceOracleDialog.scala
@@ -186,7 +186,7 @@ object InitMultiNonceOracleDialog {
       }
     }
 
-    dialog.dialogPane().content = new VBox() {
+    val vBoxContent: VBox = new VBox() {
       padding = Insets(20, 10, 10, 10)
       spacing = 10
       alignment = Pos.Center
@@ -257,6 +257,10 @@ object InitMultiNonceOracleDialog {
                         outcomes,
                         roundingAccordion,
                         previewGraphButton)
+    }
+
+    dialog.dialogPane().content = new ScrollPane() {
+      content = vBoxContent
     }
     // Enable/Disable OK button depending on whether all data was entered.
     val okButton = dialog.dialogPane().lookupButton(ButtonType.OK)

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/InitNumericContractDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/InitNumericContractDialog.scala
@@ -20,7 +20,7 @@ import scalafx.stage.Window
 
 import scala.util.{Failure, Success, Try}
 
-object InitMultiNonceOracleDialog {
+object InitNumericContractDialog {
 
   def showAndWait(parentWindow: Window): Option[MultiNonceContractInfo] = {
     val dialog =
@@ -44,6 +44,7 @@ object InitMultiNonceOracleDialog {
       promptText = "Satoshis"
     }
     setNumericInput(baseTF)
+    setNumericInput(numDigitsTF)
     setNumericInput(totalCollateralTF)
 
     val pointMap: scala.collection.mutable.Map[

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/InitSingleNonceOracleDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/InitSingleNonceOracleDialog.scala
@@ -4,77 +4,90 @@ import org.bitcoins.commons.jsonmodels.dlc.DLCMessage.SingleNonceContractInfo
 import org.bitcoins.core.currency.Satoshis
 import org.bitcoins.core.protocol.tlv.EnumOutcome
 import org.bitcoins.gui.GlobalData
+import org.bitcoins.gui.util.GUIUtil.setNumericInput
 import scalafx.Includes._
-import scalafx.application.Platform
-import scalafx.geometry.Insets
-import scalafx.scene.control.{ButtonType, Dialog, Label, TextField}
-import scalafx.scene.layout.GridPane
+import scalafx.geometry.{Insets, Pos}
+import scalafx.scene.control.{Label, _}
+import scalafx.scene.layout._
 import scalafx.stage.Window
+
+import scala.collection._
 
 object InitSingleNonceOracleDialog {
 
-  def showAndWait(
-      parentWindow: Window,
-      numOutcomes: Int): Option[SingleNonceContractInfo] = {
+  def showAndWait(parentWindow: Window): Option[SingleNonceContractInfo] = {
     val dialog =
-      new Dialog[Option[(Vector[String], SingleNonceContractInfo)]]() {
+      new Dialog[Option[SingleNonceContractInfo]]() {
         initOwner(parentWindow)
         title = "Initialize Demo Oracle"
         headerText = "Enter contract outcomes and their outcome values"
       }
 
-    val fields =
-      (0 until numOutcomes).map(_ =>
-        (new TextField(),
-         new TextField() {
-           promptText = "Satoshis"
-         }))
-
     dialog.dialogPane().buttonTypes = Seq(ButtonType.OK, ButtonType.Cancel)
     dialog.dialogPane().stylesheets = GlobalData.currentStyleSheets
+    dialog.resizable = true
 
-    dialog.dialogPane().content = new GridPane {
-      hgap = 10
-      vgap = 10
-      padding = Insets(20, 100, 10, 10)
+    val fields: mutable.Map[Int, (TextField, TextField)] = mutable.Map.empty
+
+    var nextRow: Int = 1
+    val gridPane = new GridPane {
+      alignment = Pos.Center
+      padding = Insets(top = 10, right = 10, bottom = 10, left = 10)
+      hgap = 5
+      vgap = 5
 
       add(new Label("Outcomes"), 0, 0)
       add(new Label("Values"), 1, 0)
-
-      var nextRow: Int = 1
-
-      fields.foreach {
-        case (str, value) =>
-          add(str, 0, nextRow)
-          add(value, 1, nextRow)
-          nextRow += 1
-      }
     }
 
-    // Enable/Disable OK button depending on whether all data was entered.
-    val okButton = dialog.dialogPane().lookupButton(ButtonType.OK)
-    // Simple validation that sufficient data was entered
-    okButton.disable <== fields
-      .map { case (str, value) => str.text.isEmpty || value.text.isEmpty }
-      .reduce(_ || _)
+    def addOutcomeRow(): Unit = {
 
-    // Request focus on the first field by default.
-    Platform.runLater(fields.head._1.requestFocus())
+      val outcomeTF = new TextField()
+      val amtTF = new TextField() {
+        promptText = "Satoshis"
+      }
+      setNumericInput(amtTF)
+
+      val row = nextRow
+      fields.addOne(row, (outcomeTF, amtTF))
+
+      gridPane.add(outcomeTF, 0, row)
+      gridPane.add(amtTF, 1, row)
+
+      nextRow += 1
+      dialog.dialogPane().getScene.getWindow.sizeToScene()
+    }
+
+    addOutcomeRow()
+    addOutcomeRow()
+
+    val addPointButton: Button = new Button("+ Outcome") {
+      onAction = _ => addOutcomeRow()
+    }
+
+    val bottom = new HBox() {
+      spacing = 10
+      alignment = Pos.BottomRight
+      children = Vector(addPointButton)
+    }
+
+    dialog.dialogPane().content = new VBox(gridPane, bottom)
 
     // When the OK button is clicked, convert the result to a CreateDLCOffer.
     dialog.resultConverter = dialogButton =>
       if (dialogButton == ButtonType.OK) {
-        val inputs = fields.map {
-          case (str, value) => (str.text(), value.text())
+        val inputs = fields.values.flatMap {
+          case (str, value) =>
+            if (str.text.value.nonEmpty && value.text.value.nonEmpty)
+              Some((str.text(), value.text()))
+            else None
         }
         val contractMap = inputs.map {
           case (str, value) =>
             EnumOutcome(str) -> Satoshis(BigInt(value))
         }.toVector
 
-        val outcomes = inputs.map(_._1).toVector
-
-        Some((outcomes, SingleNonceContractInfo(contractMap)))
+        Some(SingleNonceContractInfo(contractMap))
       } else None
 
     val result = dialog.showAndWait()

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/InitSingleNonceOracleDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/InitSingleNonceOracleDialog.scala
@@ -11,11 +11,11 @@ import scalafx.scene.control.{ButtonType, Dialog, Label, TextField}
 import scalafx.scene.layout.GridPane
 import scalafx.stage.Window
 
-object InitOracleDialog {
+object InitSingleNonceOracleDialog {
 
   def showAndWait(
       parentWindow: Window,
-      numOutcomes: Int): Option[(Vector[String], SingleNonceContractInfo)] = {
+      numOutcomes: Int): Option[SingleNonceContractInfo] = {
     val dialog =
       new Dialog[Option[(Vector[String], SingleNonceContractInfo)]]() {
         initOwner(parentWindow)
@@ -80,10 +80,8 @@ object InitOracleDialog {
     val result = dialog.showAndWait()
 
     result match {
-      case Some(
-            Some(
-              (outcomes: Vector[_], contractInfo: SingleNonceContractInfo))) =>
-        Some((outcomes.map(_.toString), contractInfo))
+      case Some(Some(contractInfo: SingleNonceContractInfo)) =>
+        Some(contractInfo)
       case Some(_) | None => None
     }
   }

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/OfferDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/OfferDLCDialog.scala
@@ -6,6 +6,7 @@ import org.bitcoins.core.currency.Satoshis
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.tlv.ContractInfoTLV
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
+import scalafx.scene.Node
 
 object OfferDLCDialog
     extends DLCDialog[CreateDLCOffer]("Create DLC Offer",
@@ -14,25 +15,26 @@ object OfferDLCDialog
                                       Vector(DLCDialog.feeRateStr)) {
   import DLCDialog._
 
-  override def constructFromInput(
-      inputs: Map[String, String]): CreateDLCOffer = {
-    val feeRate = if (inputs(feeRateStr).isEmpty) {
+  override def constructFromInput(inputs: Map[String, Node]): CreateDLCOffer = {
+    val feeRate = if (readStringFromNode(inputs(feeRateStr)).isEmpty) {
       None
     } else {
       Some(
         SatoshisPerVirtualByte(
-          Satoshis(BigInt(inputs(feeRateStr)))
+          Satoshis(BigInt(readStringFromNode(inputs(feeRateStr))))
         )
       )
     }
 
     CreateDLCOffer(
-      oracleInfo = DLCMessage.OracleInfo.fromHex(inputs(oracleInfoStr)),
-      contractInfo = ContractInfoTLV.fromHex(inputs(contractInfoStr)),
-      collateral = Satoshis(BigInt(inputs(collateralStr))),
+      oracleInfo = DLCMessage.OracleInfo.fromHex(
+        readStringFromNode(inputs(oracleInfoStr))),
+      contractInfo =
+        ContractInfoTLV.fromHex(readStringFromNode(inputs(contractInfoStr))),
+      collateral = Satoshis(BigInt(readStringFromNode(inputs(collateralStr)))),
       feeRateOpt = feeRate,
-      locktime = UInt32(BigInt(inputs(locktimeStr))),
-      refundLT = UInt32(BigInt(inputs(refundLocktimeStr)))
+      locktime = UInt32(BigInt(readStringFromNode(inputs(locktimeStr)))),
+      refundLT = UInt32(BigInt(readStringFromNode(inputs(refundLocktimeStr))))
     )
   }
 }

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/OfferDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/OfferDLCDialog.scala
@@ -4,6 +4,7 @@ import org.bitcoins.cli.CliCommand.CreateDLCOffer
 import org.bitcoins.commons.jsonmodels.dlc.DLCMessage
 import org.bitcoins.core.currency.Satoshis
 import org.bitcoins.core.number.UInt32
+import org.bitcoins.core.protocol.tlv.ContractInfoTLV
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 
 object OfferDLCDialog
@@ -27,7 +28,7 @@ object OfferDLCDialog
 
     CreateDLCOffer(
       oracleInfo = DLCMessage.OracleInfo.fromHex(inputs(oracleInfoStr)),
-      contractInfo = DLCMessage.ContractInfo.fromHex(inputs(contractInfoStr)),
+      contractInfo = ContractInfoTLV.fromHex(inputs(contractInfoStr)),
       collateral = Satoshis(BigInt(inputs(collateralStr))),
       feeRateOpt = feeRate,
       locktime = UInt32(BigInt(inputs(locktimeStr))),

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/RefundDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/RefundDLCDialog.scala
@@ -1,19 +1,19 @@
 package org.bitcoins.gui.dlc.dialog
 
 import org.bitcoins.cli.CliCommand.ExecuteDLCRefund
-import org.bitcoins.crypto.Sha256Digest
 import scalafx.scene.control.TextField
+import scodec.bits.ByteVector
 
 object RefundDLCDialog
     extends DLCDialog[ExecuteDLCRefund](
       "DLC Refund",
-      "Enter DLC event ID",
+      "Enter DLC contract ID",
       Vector(DLCDialog.dlcContractIdStr -> new TextField())) {
   import DLCDialog._
 
   override def constructFromInput(
       inputs: Map[String, String]): ExecuteDLCRefund = {
-    val eventId = Sha256Digest(inputs(dlcContractIdStr))
-    ExecuteDLCRefund(eventId, noBroadcast = false)
+    val contractId = ByteVector.fromValidHex(inputs(dlcContractIdStr))
+    ExecuteDLCRefund(contractId, noBroadcast = false)
   }
 }

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/RefundDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/RefundDLCDialog.scala
@@ -1,6 +1,7 @@
 package org.bitcoins.gui.dlc.dialog
 
 import org.bitcoins.cli.CliCommand.ExecuteDLCRefund
+import scalafx.scene.Node
 import scalafx.scene.control.TextField
 import scodec.bits.ByteVector
 
@@ -12,8 +13,10 @@ object RefundDLCDialog
   import DLCDialog._
 
   override def constructFromInput(
-      inputs: Map[String, String]): ExecuteDLCRefund = {
-    val contractId = ByteVector.fromValidHex(inputs(dlcContractIdStr))
+      inputs: Map[String, Node]): ExecuteDLCRefund = {
+    val hex = readStringFromNode(inputs(dlcContractIdStr))
+
+    val contractId = ByteVector.fromValidHex(hex)
     ExecuteDLCRefund(contractId, noBroadcast = false)
   }
 }

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/SignDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/SignDLCDialog.scala
@@ -11,7 +11,7 @@ object SignDLCDialog
   import DLCDialog._
 
   override def constructFromInput(inputs: Map[String, String]): SignDLC = {
-    val accept = LnMessageFactory(DLCAcceptTLV).fromHex(dlcAcceptStr)
+    val accept = LnMessageFactory(DLCAcceptTLV).fromHex(inputs(dlcAcceptStr))
     SignDLC(accept)
   }
 }

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/SignDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/SignDLCDialog.scala
@@ -5,17 +5,21 @@ import org.bitcoins.core.protocol.tlv._
 import scalafx.scene.Node
 
 object SignDLCDialog
-    extends DLCDialog[SignDLCCliCommand](
-      "Sign DLC",
-      "Enter DLC accept message",
-      Vector(
-        DLCDialog.dlcAcceptStr -> DLCDialog
-          .textArea(),
-        "Open Accept from File" ->
-          DLCDialog.fileChooserButton(file =>
-            DLCDialog.acceptDLCFile = Some(file))
-      ),
-      Vector(DLCDialog.dlcAcceptStr, DLCDialog.dlcAcceptFileStr)) {
+    extends DLCDialog[SignDLCCliCommand]("Sign DLC",
+                                         "Enter DLC Accept message",
+                                         Vector(
+                                           DLCDialog.dlcAcceptStr -> DLCDialog
+                                             .textArea(),
+                                           "Open Accept from File" ->
+                                             DLCDialog.fileChooserButton { file =>
+                                               DLCDialog.acceptDLCFile =
+                                                 Some(file)
+                                               DLCDialog.acceptFileChosenLabel.text =
+                                                 file.toString
+                                             }
+                                         ),
+                                         Vector(DLCDialog.dlcAcceptStr,
+                                                DLCDialog.dlcAcceptFileStr)) {
   import DLCDialog._
 
   override def constructFromInput(
@@ -23,6 +27,7 @@ object SignDLCDialog
     acceptDLCFile match {
       case Some(file) =>
         acceptDLCFile = None // reset
+        acceptFileChosenLabel.text = "" // reset
         SignDLCFromFile(file.toPath)
       case None =>
         val acceptHex = readStringFromNode(inputs(dlcAcceptStr))

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/SignDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/SignDLCDialog.scala
@@ -1,17 +1,34 @@
 package org.bitcoins.gui.dlc.dialog
 
-import org.bitcoins.cli.CliCommand.SignDLC
+import org.bitcoins.cli.CliCommand._
 import org.bitcoins.core.protocol.tlv._
+import scalafx.scene.Node
 
 object SignDLCDialog
-    extends DLCDialog[SignDLC](
+    extends DLCDialog[SignDLCCliCommand](
       "Sign DLC",
       "Enter DLC accept message",
-      Vector(DLCDialog.dlcAcceptStr -> DLCDialog.textArea())) {
+      Vector(
+        DLCDialog.dlcAcceptStr -> DLCDialog
+          .textArea(),
+        "Open Accept from File" ->
+          DLCDialog.fileChooserButton(file =>
+            DLCDialog.acceptDLCFile = Some(file))
+      ),
+      Vector(DLCDialog.dlcAcceptStr, DLCDialog.dlcAcceptFileStr)) {
   import DLCDialog._
 
-  override def constructFromInput(inputs: Map[String, String]): SignDLC = {
-    val accept = LnMessageFactory(DLCAcceptTLV).fromHex(inputs(dlcAcceptStr))
-    SignDLC(accept)
+  override def constructFromInput(
+      inputs: Map[String, Node]): SignDLCCliCommand = {
+    acceptDLCFile match {
+      case Some(file) =>
+        acceptDLCFile = None // reset
+        SignDLCFromFile(file.toPath)
+      case None =>
+        val acceptHex = readStringFromNode(inputs(dlcAcceptStr))
+
+        val accept = LnMessageFactory(DLCAcceptTLV).fromHex(acceptHex)
+        SignDLC(accept)
+    }
   }
 }

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/SignDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/SignDLCDialog.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.gui.dlc.dialog
 
 import org.bitcoins.cli.CliCommand.SignDLC
-import org.bitcoins.commons.jsonmodels.dlc.DLCMessage.DLCAccept
+import org.bitcoins.core.protocol.tlv.DLCAcceptTLV
 
 object SignDLCDialog
     extends DLCDialog[SignDLC](
@@ -11,7 +11,7 @@ object SignDLCDialog
   import DLCDialog._
 
   override def constructFromInput(inputs: Map[String, String]): SignDLC = {
-    val accept = DLCAccept.fromJson(ujson.read(inputs(dlcAcceptStr)))
+    val accept = DLCAcceptTLV(dlcAcceptStr)
     SignDLC(accept)
   }
 }

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/SignDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/SignDLCDialog.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.gui.dlc.dialog
 
 import org.bitcoins.cli.CliCommand.SignDLC
-import org.bitcoins.core.protocol.tlv.DLCAcceptTLV
+import org.bitcoins.core.protocol.tlv._
 
 object SignDLCDialog
     extends DLCDialog[SignDLC](
@@ -11,7 +11,7 @@ object SignDLCDialog
   import DLCDialog._
 
   override def constructFromInput(inputs: Map[String, String]): SignDLC = {
-    val accept = DLCAcceptTLV(dlcAcceptStr)
+    val accept = LnMessageFactory(DLCAcceptTLV).fromHex(dlcAcceptStr)
     SignDLC(accept)
   }
 }

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/ViewDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/ViewDLCDialog.scala
@@ -151,10 +151,12 @@ object ViewDLCDialog {
           rowIndex = row)
 
       row += 1
-      add(new Label("Oracle Signature:"), 0, row)
+      add(new Label("Oracle Signatures:"), 0, row)
       add(new TextField() {
-            text =
-              DLCStatus.getOracleSignature(dlcStatus).map(_.hex).getOrElse("")
+            text = DLCStatus
+              .getOracleSignatures(dlcStatus)
+              .map(_.map(_.hex).mkString(","))
+              .getOrElse("")
             editable = false
           },
           columnIndex = 1,

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/ViewDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/ViewDLCDialog.scala
@@ -1,6 +1,5 @@
 package org.bitcoins.gui.dlc.dialog
 
-import org.bitcoins.commons.jsonmodels.dlc.DLCStatus._
 import org.bitcoins.commons.jsonmodels.dlc._
 import org.bitcoins.gui.GlobalData
 import scalafx.Includes._
@@ -11,7 +10,7 @@ import scalafx.stage.Window
 
 object ViewDLCDialog {
 
-  def showAndWait(parentWindow: Window, dlcStatus: DLCStatus): Unit = {
+  def showAndWait(parentWindow: Window, status: SerializedDLCStatus): Unit = {
     val dialog = new Dialog[Unit]() {
       initOwner(parentWindow)
       title = "View DLC"
@@ -29,7 +28,7 @@ object ViewDLCDialog {
       private var row = 0
       add(new Label("Param Hash:"), 0, row)
       add(new TextField() {
-            text = dlcStatus.paramHash.hex
+            text = status.paramHash.hex
             editable = false
           },
           columnIndex = 1,
@@ -38,7 +37,7 @@ object ViewDLCDialog {
       row += 1
       add(new Label("Initiator:"), 0, row)
       add(new TextField() {
-            text = if (dlcStatus.isInitiator) "Yes" else "No"
+            text = if (status.isInitiator) "Yes" else "No"
             editable = false
           },
           columnIndex = 1,
@@ -47,7 +46,7 @@ object ViewDLCDialog {
       row += 1
       add(new Label("State:"), 0, row)
       add(new TextField() {
-            text = dlcStatus.statusString
+            text = status.statusString
             editable = false
           },
           columnIndex = 1,
@@ -56,7 +55,7 @@ object ViewDLCDialog {
       row += 1
       add(new Label("Temp Contract Id:"), 0, row)
       add(new TextField() {
-            text = dlcStatus.tempContractId.hex
+            text = status.tempContractId.hex
             editable = false
           },
           columnIndex = 1,
@@ -64,17 +63,19 @@ object ViewDLCDialog {
 
       row += 1
       add(new Label("Contract Id:"), 0, row)
-      add(new TextField() {
-            text = DLCStatus.getContractId(dlcStatus).map(_.toHex).getOrElse("")
-            editable = false
-          },
-          columnIndex = 1,
-          rowIndex = row)
+      add(
+        new TextField() {
+          text =
+            SerializedDLCStatus.getContractId(status).map(_.toHex).getOrElse("")
+          editable = false
+        },
+        columnIndex = 1,
+        rowIndex = row)
 
       row += 1
       add(new Label("Oracle Info:"), 0, row)
       add(new TextField() {
-            text = dlcStatus.offer.oracleInfo.hex
+            text = status.oracleInfo.hex
             editable = false
           },
           columnIndex = 1,
@@ -83,7 +84,7 @@ object ViewDLCDialog {
       row += 1
       add(new Label("Fee Rate:"), 0, row)
       add(new TextField() {
-            text = s"${dlcStatus.offer.feeRate.toLong} sats/vbyte"
+            text = s"${status.feeRate.toLong} sats/vbyte"
             editable = false
           },
           columnIndex = 1,
@@ -92,8 +93,7 @@ object ViewDLCDialog {
       row += 1
       add(new Label("Contract Maturity:"), 0, row)
       add(new TextField() {
-            text =
-              dlcStatus.offer.timeouts.contractMaturity.toUInt32.toLong.toString
+            text = status.timeouts.contractMaturity.toUInt32.toLong.toString
             editable = false
           },
           columnIndex = 1,
@@ -102,8 +102,7 @@ object ViewDLCDialog {
       row += 1
       add(new Label("Contract Timeout:"), 0, row)
       add(new TextField() {
-            text =
-              dlcStatus.offer.timeouts.contractTimeout.toUInt32.toLong.toString
+            text = status.timeouts.contractTimeout.toUInt32.toLong.toString
             editable = false
           },
           columnIndex = 1,
@@ -113,17 +112,7 @@ object ViewDLCDialog {
       add(new Label("Collateral:"), 0, row)
       add(
         new TextField() {
-          val num: Long = if (dlcStatus.isInitiator) {
-            dlcStatus.offer.totalCollateral.toLong
-          } else {
-            dlcStatus match {
-              case _: Offered => 0
-              case accepted: AcceptedDLCStatus =>
-                accepted.accept.totalCollateral.toLong
-            }
-          }
-
-          text = num.toString
+          text = status.totalCollateral.satoshis.toLong.toString
           editable = false
         },
         columnIndex = 1,
@@ -132,35 +121,39 @@ object ViewDLCDialog {
 
       row += 1
       add(new Label("Funding TxId:"), 0, row)
-      add(new TextField() {
-            text =
-              DLCStatus.getFundingTx(dlcStatus).map(_.txIdBE.hex).getOrElse("")
-            editable = false
-          },
-          columnIndex = 1,
-          rowIndex = row)
+      add(
+        new TextField() {
+          text =
+            SerializedDLCStatus.getFundingTxId(status).map(_.hex).getOrElse("")
+          editable = false
+        },
+        columnIndex = 1,
+        rowIndex = row)
 
       row += 1
       add(new Label("Closing TxId:"), 0, row)
-      add(new TextField() {
-            text =
-              DLCStatus.getClosingTx(dlcStatus).map(_.txIdBE.hex).getOrElse("")
-            editable = false
-          },
-          columnIndex = 1,
-          rowIndex = row)
+      add(
+        new TextField() {
+          text =
+            SerializedDLCStatus.getClosingTxId(status).map(_.hex).getOrElse("")
+          editable = false
+        },
+        columnIndex = 1,
+        rowIndex = row)
 
       row += 1
       add(new Label("Oracle Signatures:"), 0, row)
-      add(new TextField() {
-            text = DLCStatus
-              .getOracleSignatures(dlcStatus)
-              .map(_.map(_.hex).mkString(","))
-              .getOrElse("")
-            editable = false
-          },
-          columnIndex = 1,
-          rowIndex = row)
+      add(
+        new TextField() {
+          text = SerializedDLCStatus
+            .getOracleSignatures(status)
+            .map(_.map(_.hex).mkString(","))
+            .getOrElse("")
+          editable = false
+        },
+        columnIndex = 1,
+        rowIndex = row
+      )
 
     }
 

--- a/app/gui/src/main/scala/org/bitcoins/gui/util/GUIUtil.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/util/GUIUtil.scala
@@ -1,0 +1,18 @@
+package org.bitcoins.gui.util
+
+import scalafx.Includes._
+import scalafx.scene.control.TextField
+
+object GUIUtil {
+
+  def setNumericInput(textField: TextField): Unit = {
+    textField.text.addListener {
+      (
+          _: javafx.beans.value.ObservableValue[_ <: String],
+          _: String,
+          newVal: String) =>
+        if (!newVal.matches("\\d*"))
+          textField.setText(newVal.replaceAll("[^\\d]", ""))
+    }
+  }
+}

--- a/app/gui/src/main/scala/org/bitcoins/gui/util/GUIUtil.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/util/GUIUtil.scala
@@ -11,8 +11,8 @@ object GUIUtil {
           _: javafx.beans.value.ObservableValue[_ <: String],
           _: String,
           newVal: String) =>
-        if (!newVal.matches("\\d*"))
-          textField.setText(newVal.replaceAll("[^\\d]", ""))
+        if (!newVal.matches("-?\\d*"))
+          textField.setText(newVal.replaceAll("[^-?\\d]", ""))
     }
   }
 }

--- a/app/oracle-server/src/main/resources/reference.conf
+++ b/app/oracle-server/src/main/resources/reference.conf
@@ -1,0 +1,8 @@
+akka {
+
+  # Set these to the defaults instead of the
+  # appServer's modified ones
+  http.server.request-timeout = 10s
+  http.server.parsing.max-content-length = 8m
+  http.client.parsing.max-content-length = 8m
+}

--- a/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
@@ -889,7 +889,8 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
           oracleSigsOpt = None,
           fundingOutPointOpt = None,
           fundingTxIdOpt = None,
-          closingTxIdOpt = None
+          closingTxIdOpt = None,
+          outcomeOpt = None
         )))
 
       val route = walletRoutes.handleCommand(

--- a/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
@@ -6,14 +6,7 @@ import akka.http.scaladsl.model.ContentTypes._
 import akka.http.scaladsl.server.ValidationRejection
 import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
 import org.bitcoins.commons.jsonmodels.dlc.DLCMessage._
-import org.bitcoins.commons.jsonmodels.dlc.{
-  CETSignatures,
-  DLCFundingInputP2WPKHV0,
-  DLCPublicKeys,
-  DLCState,
-  DLCTimeouts,
-  FundingSignatures
-}
+import org.bitcoins.commons.jsonmodels.dlc._
 import org.bitcoins.core.Core
 import org.bitcoins.core.api.chain.ChainApi
 import org.bitcoins.core.api.wallet.db._
@@ -30,7 +23,7 @@ import org.bitcoins.core.protocol.BlockStamp.{
   InvalidBlockStamp
 }
 import org.bitcoins.core.protocol.script.{EmptyScriptWitness, P2WPKHWitnessV0}
-import org.bitcoins.core.protocol.tlv.EnumOutcome
+import org.bitcoins.core.protocol.tlv._
 import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.protocol.{
   Bech32Address,
@@ -44,9 +37,9 @@ import org.bitcoins.core.util.FutureUtil
 import org.bitcoins.core.wallet.fee.{FeeUnit, SatoshisPerVirtualByte}
 import org.bitcoins.core.wallet.utxo._
 import org.bitcoins.crypto._
+import org.bitcoins.dlc.wallet.models._
 import org.bitcoins.node.Node
 import org.bitcoins.wallet.MockWalletApi
-import org.bitcoins.dlc.wallet.models._
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.wordspec.AnyWordSpec
 import scodec.bits.ByteVector
@@ -729,29 +722,31 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
     val oracleInfoStr =
       "6374dfae2e50d01752a44943b4b6990043f2880275d5d681903ea4ee35f58603bd6a790503e4068f8629b15ac13b25200632f6a6e4f6880b81f23b1d129b52b1"
 
-    val contractInfo = SingleNonceContractInfo(
-      "ffbbcde836cee437a2fa4ef7db1ea3d79ca71c0c821d2a197dda51bc6534f5628813000000000000e770f42c578084a4a096ce1085f7fe508f8d908d2c5e6e304b2c3eab9bc973ea8813000000000000")
-
     val contractInfoDigests =
       Vector("ffbbcde836cee437a2fa4ef7db1ea3d79ca71c0c821d2a197dda51bc6534f562",
              "e770f42c578084a4a096ce1085f7fe508f8d908d2c5e6e304b2c3eab9bc973ea")
 
+    val contractInfo = SingleNonceContractInfo.fromStringVec(
+      Vector(
+        (contractInfoDigests.head, Satoshis(5)),
+        (contractInfoDigests.last, Satoshis(4))
+      ))
+
+    val contractInfoTLV = contractInfo.toTLV
+
     val contractMaturity = 1580323752
     val contractTimeout = 1581323752
 
-    val dummyKey = ECPublicKey(
-      "024c6eb53573aae186dbb1a93274cc00c795473d7cfe2cb69e7d185ee28a39b919")
+    val dummyKey = ECPrivateKey.freshPrivateKey
+    val dummyPubKey = dummyKey.publicKey
 
-    val dummyPartialSig = PartialSignature(
-      ECPublicKey(
-        "024c6eb53573aae186dbb1a93274cc00c795473d7cfe2cb69e7d185ee28a39b919"),
-      DummyECDigitalSignature)
+    val dummySig = dummyKey.sign(Sha256DigestBE.empty)
+
+    val dummyPartialSig = PartialSignature(dummyPubKey, dummySig)
 
     val dummyScriptWitness: P2WPKHWitnessV0 = {
       P2WPKHWitnessV0(dummyPartialSig.pubKey, dummyPartialSig.signature)
     }
-
-    val dummyAdaptorSig = ECAdaptorSignature.dummy
 
     val dummyOracleSig = SchnorrDigitalSignature(
       "65ace55b5d073cc7a1c783fa8c254692c421270fa988247e3c87627ffe804ed06c20bf779da91f82da3311b1d9e0a3a513409a15c66f25201280751177dad24c")
@@ -767,7 +762,7 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
     val dummyAddress = "bc1quq29mutxkgxmjfdr7ayj3zd9ad0ld5mrhh89l2"
 
     val dummyDLCKeys =
-      DLCPublicKeys(dummyKey, BitcoinAddress(dummyAddress))
+      DLCPublicKeys(dummyPubKey, BitcoinAddress(dummyAddress))
 
     val paramHash = Sha256DigestBE(
       "de462f212d95ca4cf5db54eee08f14be0ee934e9ecfc6e9b7014ecfa51ba7b66")
@@ -781,39 +776,40 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
     val fundingInput: DLCFundingInputP2WPKHV0 =
       DLCFundingInputP2WPKHV0(wtx, UInt32.zero, UInt32.zero)
 
-    "create a dlc offer" in {
+    val offer = DLCOffer(
+      OracleAndContractInfo(OracleInfo(oracleInfoStr), contractInfo),
+      dummyDLCKeys,
+      Satoshis(2500),
+      Vector(fundingInput, fundingInput),
+      Bech32Address.fromString(dummyAddress),
+      SatoshisPerVirtualByte.one,
+      DLCTimeouts(BlockStamp(contractMaturity), BlockStamp(contractTimeout))
+    )
 
+    "create a dlc offer" in {
       (mockWalletApi
         .createDLCOffer(_: OracleInfo,
-                        _: ContractInfo,
+                        _: ContractInfoTLV,
                         _: Satoshis,
-                        _: Option[SatoshisPerVirtualByte],
+                        _: Option[FeeUnit],
                         _: UInt32,
                         _: UInt32))
         .expects(
           OracleInfo(oracleInfoStr),
-          contractInfo,
+          contractInfoTLV,
           Satoshis(2500),
           Some(SatoshisPerVirtualByte(Satoshis.one)),
           UInt32(contractMaturity),
           UInt32(contractTimeout)
         )
-        .returning(Future.successful(DLCOffer(
-          OracleAndContractInfo(OracleInfo(oracleInfoStr), contractInfo),
-          dummyDLCKeys,
-          Satoshis(2500),
-          Vector(fundingInput, fundingInput),
-          Bech32Address.fromString(dummyAddress),
-          SatoshisPerVirtualByte.one,
-          DLCTimeouts(BlockStamp(contractMaturity), BlockStamp(contractTimeout))
-        )))
+        .returning(Future.successful(offer))
 
       val route = walletRoutes.handleCommand(
         ServerCommand(
           "createdlcoffer",
           Arr(
             Str(oracleInfoStr),
-            Str(contractInfo.hex),
+            Str(contractInfoTLV.hex),
             Num(2500),
             Num(1),
             Num(contractMaturity),
@@ -823,76 +819,68 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
 
       Post() ~> route ~> check {
         assert(contentType == `application/json`)
-        assert(responseAs[
-          String] == s"""{"result":{"contractInfo":[{"outcome":"${contractInfo.keys.head.outcome}","sats":${contractInfo.values.head.toLong}},{"outcome":"${contractInfo.keys.last.outcome}","sats":${contractInfo.values.last.toLong}}],"oracleInfo":"$oracleInfoStr","pubKeys":{"fundingKey":"${dummyKey.hex}","payoutAddress":"$dummyAddress"},"totalCollateral":2500,"fundingInputs":[{"prevTx":"${fundingInput.prevTx.hex}","prevTxVout":${fundingInput.prevTxVout.toInt},"sequence":${fundingInput.sequence.toInt},"maxWitnessLength":${fundingInput.maxWitnessLen.toInt}},{"prevTx":"${fundingInput.prevTx.hex}","prevTxVout":${fundingInput.prevTxVout.toInt},"sequence":${fundingInput.sequence.toInt},"maxWitnessLength":${fundingInput.maxWitnessLen.toInt}}],"changeAddress":"$dummyAddress","feeRate":1,"timeouts":{"contractMaturity":$contractMaturity,"contractTimeout":$contractTimeout}},"error":null}""")
+        assert(
+          responseAs[
+            String] == s"""{"result":"${offer.toTLV.hex}","error":null}""")
       }
     }
+
+    val accept = DLCAccept(
+      Satoshis(1000),
+      dummyDLCKeys,
+      Vector(fundingInput),
+      Bech32Address
+        .fromString(dummyAddress),
+      CETSignatures(dummyOutcomeSigs, dummyPartialSig),
+      Sha256Digest.empty
+    )
 
     "accept a dlc offer" in {
-      val offerStr =
-        s"""{"contractInfo":[{"outcome":"${contractInfoDigests.head}","sats":5},{"outcome":"${contractInfoDigests.last}","sats":4}],"oracleInfo":"$oracleInfoStr","pubKeys":{"fundingKey":"${dummyKey.hex}","payoutAddress":"$dummyAddress"},"totalCollateral":10000000000,"fundingInputs":[{"prevTx":"${fundingInput.prevTx.hex}","prevTxVout":${fundingInput.prevTxVout.toInt},"sequence":${fundingInput.sequence.toInt},"maxWitnessLength":${fundingInput.maxWitnessLen.toInt}}],"changeAddress":"$dummyAddress","feeRate":1,"timeouts":{"contractMaturity":$contractMaturity,"contractTimeout":$contractTimeout}}"""
-
-      val sats = Satoshis.max
-
       (mockWalletApi
-        .acceptDLCOffer(_: DLCOffer))
-        .expects(DLCOffer.fromJson(ujson.read(offerStr)))
-        .returning(
-          Future.successful(
-            DLCAccept(
-              sats,
-              dummyDLCKeys,
-              Vector(fundingInput),
-              Bech32Address
-                .fromString(dummyAddress),
-              CETSignatures(dummyOutcomeSigs, dummyPartialSig),
-              Sha256Digest.empty
-            ))
-        )
+        .acceptDLCOffer(_: DLCOfferTLV))
+        .expects(offer.toTLV)
+        .returning(Future.successful(accept))
 
       val route = walletRoutes.handleCommand(
-        ServerCommand("acceptdlcoffer", Arr(Str(offerStr))))
+        ServerCommand("acceptdlcoffer", Arr(Str(offer.toTLV.hex))))
 
       Post() ~> route ~> check {
         assert(contentType == `application/json`)
-        assert(responseAs[
-          String] == s"""{"result":{"totalCollateral":${sats.toLong},"pubKeys":{"fundingKey":"${dummyKey.hex}","payoutAddress":"$dummyAddress"},"fundingInputs":[{"prevTx":"${fundingInput.prevTx.hex}","prevTxVout":${fundingInput.prevTxVout.toInt},"sequence":${fundingInput.sequence.toInt},"maxWitnessLength":${fundingInput.maxWitnessLen.toInt}}],"changeAddress":"$dummyAddress","cetSigs":{"outcomeSigs":[{"$winStr":"${dummyAdaptorSig.hex}"},{"$loseStr":"${dummyAdaptorSig.hex}"}],"refundSig":"${dummyPartialSig.hex}"},"tempContractId":"${Sha256Digest.empty.hex}"},"error":null}""")
+        assert(
+          responseAs[
+            String] == s"""{"result":"${accept.toTLV.hex}","error":null}""")
       }
     }
 
+    val sign = DLCSign(
+      CETSignatures(dummyOutcomeSigs, dummyPartialSig),
+      FundingSignatures(Vector((EmptyTransactionOutPoint, dummyScriptWitness))),
+      paramHash.bytes
+    )
+
     "sign a dlc" in {
-      val acceptStr =
-        s"""{"totalCollateral":10000000000,"pubKeys":{"fundingKey":"${dummyKey.hex}","payoutAddress":"$dummyAddress"},"fundingInputs":[{"prevTx":"${fundingInput.prevTx.hex}","prevTxVout":${fundingInput.prevTxVout.toInt},"sequence":${fundingInput.sequence.toInt},"maxWitnessLength":${fundingInput.maxWitnessLen.toInt}}],"changeAddress":"$dummyAddress","cetSigs":{"outcomeSigs":[{"$winStr":"${dummyAdaptorSig.hex}"},{"$loseStr":"${dummyAdaptorSig.hex}"}],"refundSig":"${dummyPartialSig.hex}"},"tempContractId":"${paramHash.hex}"}"""
 
       (mockWalletApi
-        .signDLC(_: DLCAccept))
-        .expects(DLCAccept.fromJson(ujson.read(acceptStr)))
-        .returning(
-          Future.successful(
-            DLCSign(
-              CETSignatures(dummyOutcomeSigs, dummyPartialSig),
-              FundingSignatures(
-                Vector((EmptyTransactionOutPoint, dummyScriptWitness))),
-              paramHash.bytes
-            )))
+        .signDLC(_: DLCAcceptTLV))
+        .expects(accept.toTLV)
+        .returning(Future.successful(sign))
 
       val route = walletRoutes.handleCommand(
-        ServerCommand("signdlc", Arr(Str(acceptStr))))
+        ServerCommand("signdlc", Arr(Str(accept.toTLV.hex))))
 
       Post() ~> route ~> check {
         assert(contentType == `application/json`)
-        assert(responseAs[
-          String] == s"""{"result":{"cetSigs":{"outcomeSigs":[{"$winStr":"${dummyAdaptorSig.hex}"},{"$loseStr":"${dummyAdaptorSig.hex}"}],"refundSig":"${dummyPartialSig.hex}"},"fundingSigs":{"${EmptyTransactionOutPoint.hex}":"${dummyScriptWitness.hex}"},"contractId":"${paramHash.hex}"},"error":null}""")
+        assert(
+          responseAs[
+            String] == s"""{"result":"${sign.toTLV.hex}","error":null}""")
       }
     }
 
     "add dlc sigs" in {
-      val sigsStr =
-        s"""{"cetSigs":{"outcomeSigs":[{"$winStr":"${dummyAdaptorSig.hex}"},{"$loseStr":"${dummyAdaptorSig.hex}"}],"refundSig":"${dummyPartialSig.hex}"},"fundingSigs":{"${EmptyTransactionOutPoint.hex}":"${dummyScriptWitness.hex}"},"contractId":"${contractId.toHex}"}"""
 
       (mockWalletApi
-        .addDLCSigs(_: DLCSign))
-        .expects(DLCSign.fromJson(ujson.read(sigsStr)))
+        .addDLCSigs(_: DLCSignTLV))
+        .expects(sign.toTLV)
         .returning(Future.successful(DLCDb(
           paramHash = paramHash,
           tempContractId = Sha256Digest.empty,
@@ -901,14 +889,14 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
           isInitiator = false,
           account = HDAccount(HDCoin(HDPurpose(89), HDCoinType.Testnet), 0),
           keyIndex = 0,
-          oracleSigOpt = None,
+          oracleSigsOpt = None,
           fundingOutPointOpt = None,
           fundingTxIdOpt = None,
           closingTxIdOpt = None
         )))
 
       val route = walletRoutes.handleCommand(
-        ServerCommand("adddlcsigs", Arr(Str(sigsStr))))
+        ServerCommand("adddlcsigs", Arr(Str(sign.toTLV.hex))))
 
       Post() ~> route ~> check {
         assert(contentType == `application/json`)

--- a/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
@@ -819,9 +819,8 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
 
       Post() ~> route ~> check {
         assert(contentType == `application/json`)
-        assert(
-          responseAs[
-            String] == s"""{"result":"${offer.toTLV.hex}","error":null}""")
+        assert(responseAs[String] == s"""{"result":"${LnMessage(
+          offer.toTLV).hex}","error":null}""")
       }
     }
 
@@ -842,13 +841,12 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
         .returning(Future.successful(accept))
 
       val route = walletRoutes.handleCommand(
-        ServerCommand("acceptdlcoffer", Arr(Str(offer.toTLV.hex))))
+        ServerCommand("acceptdlcoffer", Arr(Str(LnMessage(offer.toTLV).hex))))
 
       Post() ~> route ~> check {
         assert(contentType == `application/json`)
-        assert(
-          responseAs[
-            String] == s"""{"result":"${accept.toTLV.hex}","error":null}""")
+        assert(responseAs[String] == s"""{"result":"${LnMessage(
+          accept.toTLV).hex}","error":null}""")
       }
     }
 
@@ -866,13 +864,12 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
         .returning(Future.successful(sign))
 
       val route = walletRoutes.handleCommand(
-        ServerCommand("signdlc", Arr(Str(accept.toTLV.hex))))
+        ServerCommand("signdlc", Arr(Str(LnMessage(accept.toTLV).hex))))
 
       Post() ~> route ~> check {
         assert(contentType == `application/json`)
-        assert(
-          responseAs[
-            String] == s"""{"result":"${sign.toTLV.hex}","error":null}""")
+        assert(responseAs[String] == s"""{"result":"${LnMessage(
+          sign.toTLV).hex}","error":null}""")
       }
     }
 
@@ -896,7 +893,7 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
         )))
 
       val route = walletRoutes.handleCommand(
-        ServerCommand("adddlcsigs", Arr(Str(sign.toTLV.hex))))
+        ServerCommand("adddlcsigs", Arr(Str(LnMessage(sign.toTLV).hex))))
 
       Post() ~> route ~> check {
         assert(contentType == `application/json`)

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -12,10 +12,10 @@ import org.bitcoins.core.api.feeprovider.FeeRateApi
 import org.bitcoins.core.api.node.NodeApi
 import org.bitcoins.core.util.{FutureUtil, NetworkUtil}
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
+import org.bitcoins.dlc.wallet._
 import org.bitcoins.feeprovider.FeeProviderName._
 import org.bitcoins.feeprovider.MempoolSpaceTarget.HourFeeTarget
 import org.bitcoins.feeprovider._
-import org.bitcoins.dlc.wallet._
 import org.bitcoins.node._
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.models.Peer

--- a/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
@@ -456,7 +456,7 @@ object CreateDLCOffer extends ServerJsonModels {
   }
 }
 
-case class AcceptDLCOffer(offer: DLCOfferTLV)
+case class AcceptDLCOffer(offer: LnMessage[DLCOfferTLV])
 
 object AcceptDLCOffer extends ServerJsonModels {
 
@@ -464,7 +464,7 @@ object AcceptDLCOffer extends ServerJsonModels {
     jsArr.arr.toList match {
       case offerJs :: Nil =>
         Try {
-          val offer = DLCOfferTLV(offerJs.str)
+          val offer = LnMessageFactory(DLCOfferTLV).fromHex(offerJs.str)
           AcceptDLCOffer(offer)
         }
       case Nil =>
@@ -478,7 +478,7 @@ object AcceptDLCOffer extends ServerJsonModels {
   }
 }
 
-case class SignDLC(accept: DLCAcceptTLV)
+case class SignDLC(accept: LnMessage[DLCAcceptTLV])
 
 object SignDLC extends ServerJsonModels {
 
@@ -486,7 +486,7 @@ object SignDLC extends ServerJsonModels {
     jsArr.arr.toList match {
       case acceptJs :: Nil =>
         Try {
-          val accept = DLCAcceptTLV(acceptJs.str)
+          val accept = LnMessageFactory(DLCAcceptTLV).fromHex(acceptJs.str)
           SignDLC(accept)
         }
       case Nil =>
@@ -499,7 +499,7 @@ object SignDLC extends ServerJsonModels {
   }
 }
 
-case class AddDLCSigs(sigs: DLCSignTLV)
+case class AddDLCSigs(sigs: LnMessage[DLCSignTLV])
 
 object AddDLCSigs extends ServerJsonModels {
 
@@ -507,7 +507,7 @@ object AddDLCSigs extends ServerJsonModels {
     jsArr.arr.toList match {
       case sigsJs :: Nil =>
         Try {
-          val sigs = DLCSignTLV(sigsJs.str)
+          val sigs = LnMessageFactory(DLCSignTLV).fromHex(sigsJs.str)
           AddDLCSigs(sigs)
         }
       case Nil =>

--- a/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
@@ -1,5 +1,7 @@
 package org.bitcoins.server
 
+import java.io.File
+import java.nio.file.Path
 import java.time.Instant
 
 import org.bitcoins.commons.jsonmodels.bitcoind.RpcOpts.LockUnspentOutputParameter
@@ -512,6 +514,27 @@ object AddDLCSigs extends ServerJsonModels {
         }
       case Nil =>
         Failure(new IllegalArgumentException("Missing sigs argument"))
+      case other =>
+        Failure(
+          new IllegalArgumentException(
+            s"Bad number of arguments: ${other.length}. Expected: 1"))
+    }
+  }
+}
+
+case class DLCDataFromFile(path: Path)
+
+object DLCDataFromFile extends ServerJsonModels {
+
+  def fromJsArr(jsArr: ujson.Arr): Try[DLCDataFromFile] = {
+    jsArr.arr.toList match {
+      case pathJs :: Nil =>
+        Try {
+          val path = new File(pathJs.str).toPath
+          DLCDataFromFile(path)
+        }
+      case Nil =>
+        Failure(new IllegalArgumentException("Missing path argument"))
       case other =>
         Failure(
           new IllegalArgumentException(

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -7,6 +7,7 @@ import akka.stream.Materializer
 import org.bitcoins.commons.serializers.Picklers._
 import org.bitcoins.core.api.wallet.db.SpendingInfoDb
 import org.bitcoins.core.currency._
+import org.bitcoins.core.protocol.tlv.LnMessage
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.wallet.utxo.AddressLabelTagType
 import org.bitcoins.crypto.NetworkElement
@@ -249,7 +250,7 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit system: ActorSystem)
                               locktime,
                               refundLT)
               .map { offer =>
-                Server.httpSuccess(offer.toTLV.hex)
+                Server.httpSuccess(LnMessage(offer.toTLV).hex)
               }
           }
       }
@@ -261,9 +262,9 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit system: ActorSystem)
         case Success(AcceptDLCOffer(offer)) =>
           complete {
             wallet
-              .acceptDLCOffer(offer)
+              .acceptDLCOffer(offer.tlv)
               .map { accept =>
-                Server.httpSuccess(accept.toTLV.hex)
+                Server.httpSuccess(LnMessage(accept.toTLV).hex)
               }
           }
       }
@@ -275,9 +276,9 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit system: ActorSystem)
         case Success(SignDLC(accept)) =>
           complete {
             wallet
-              .signDLC(accept)
+              .signDLC(accept.tlv)
               .map { sign =>
-                Server.httpSuccess(sign.toTLV.hex)
+                Server.httpSuccess(LnMessage(sign.toTLV).hex)
               }
           }
       }
@@ -288,7 +289,7 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit system: ActorSystem)
           reject(ValidationRejection("failure", Some(exception)))
         case Success(AddDLCSigs(sigs)) =>
           complete {
-            wallet.addDLCSigs(sigs).map { db =>
+            wallet.addDLCSigs(sigs.tlv).map { db =>
               Server.httpSuccess(
                 s"Successfully added sigs to DLC ${db.contractIdOpt.get.toHex}")
             }

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -252,7 +252,7 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit system: ActorSystem)
                               locktime,
                               refundLT)
               .map { offer =>
-                Server.httpSuccess(LnMessage(offer.toTLV).hex)
+                Server.httpSuccess(offer.toMessage.hex)
               }
           }
       }
@@ -266,7 +266,7 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit system: ActorSystem)
             wallet
               .acceptDLCOffer(offer.tlv)
               .map { accept =>
-                Server.httpSuccess(LnMessage(accept.toTLV).hex)
+                Server.httpSuccess(accept.toMessage.hex)
               }
           }
       }
@@ -285,7 +285,7 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit system: ActorSystem)
             wallet
               .acceptDLCOffer(offerMessage.tlv)
               .map { accept =>
-                Server.httpSuccess(LnMessage(accept.toTLV).hex)
+                Server.httpSuccess(accept.toMessage.hex)
               }
           }
       }
@@ -299,7 +299,7 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit system: ActorSystem)
             wallet
               .signDLC(accept.tlv)
               .map { sign =>
-                Server.httpSuccess(LnMessage(sign.toTLV).hex)
+                Server.httpSuccess(sign.toMessage.hex)
               }
           }
       }
@@ -318,7 +318,7 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit system: ActorSystem)
             wallet
               .signDLC(acceptMessage.tlv)
               .map { sign =>
-                Server.httpSuccess(LnMessage(sign.toTLV).hex)
+                Server.httpSuccess(sign.toMessage.hex)
               }
           }
       }

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -224,7 +224,7 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit system: ActorSystem)
           reject(ValidationRejection("failure", Some(exception)))
         case Success(GetDLC(paramHash)) =>
           complete {
-            wallet.findDLC(paramHash).map {
+            wallet.findSerializedDLC(paramHash).map {
               case None => Server.httpSuccess(ujson.Null)
               case Some(dlc) =>
                 Server.httpSuccess(dlc.toJson)

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -219,9 +219,9 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit system: ActorSystem)
       GetDLC.fromJsArr(arr) match {
         case Failure(exception) =>
           reject(ValidationRejection("failure", Some(exception)))
-        case Success(GetDLC(eventId)) =>
+        case Success(GetDLC(paramHash)) =>
           complete {
-            wallet.findDLC(eventId).map {
+            wallet.findDLC(paramHash).map {
               case None => Server.httpSuccess(ujson.Null)
               case Some(dlc) =>
                 Server.httpSuccess(dlc.toJson)
@@ -249,7 +249,7 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit system: ActorSystem)
                               locktime,
                               refundLT)
               .map { offer =>
-                Server.httpSuccess(offer.toJson)
+                Server.httpSuccess(offer.toTLV.hex)
               }
           }
       }
@@ -263,7 +263,7 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit system: ActorSystem)
             wallet
               .acceptDLCOffer(offer)
               .map { accept =>
-                Server.httpSuccess(accept.toJson)
+                Server.httpSuccess(accept.toTLV.hex)
               }
           }
       }
@@ -277,7 +277,7 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit system: ActorSystem)
             wallet
               .signDLC(accept)
               .map { sign =>
-                Server.httpSuccess(sign.toJson)
+                Server.httpSuccess(sign.toTLV.hex)
               }
           }
       }
@@ -288,9 +288,9 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit system: ActorSystem)
           reject(ValidationRejection("failure", Some(exception)))
         case Success(AddDLCSigs(sigs)) =>
           complete {
-            wallet.addDLCSigs(sigs).map { _ =>
+            wallet.addDLCSigs(sigs).map { db =>
               Server.httpSuccess(
-                s"Successfully added sigs to DLC ${sigs.contractId.toHex}")
+                s"Successfully added sigs to DLC ${db.contractIdOpt.get.toHex}")
             }
           }
       }

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -320,14 +320,13 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit system: ActorSystem)
       }
 
     case ServerCommand("executedlc", arr) =>
-      ExecuteDLCUnilateralClose.fromJsArr(arr) match {
+      ExecuteDLC.fromJsArr(arr) match {
         case Failure(exception) =>
           reject(ValidationRejection("failure", Some(exception)))
-        case Success(
-              ExecuteDLCUnilateralClose(contractId, oracleSig, noBroadcast)) =>
+        case Success(ExecuteDLC(contractId, oracleSigs, noBroadcast)) =>
           complete {
             for {
-              tx <- wallet.executeDLC(contractId, oracleSig)
+              tx <- wallet.executeDLC(contractId, oracleSigs)
               retStr <- handleBroadcastable(tx, noBroadcast)
             } yield {
               Server.httpSuccess(retStr.hex)

--- a/core/src/main/scala/org/bitcoins/core/p2p/NetworkPayload.scala
+++ b/core/src/main/scala/org/bitcoins/core/p2p/NetworkPayload.scala
@@ -1290,7 +1290,7 @@ object VersionMessage extends Factory[VersionMessage] {
       version = ProtocolVersion.default,
       services = ServiceIdentifier.NODE_NONE,
       timestamp = Int64(java.time.Instant.now.getEpochSecond),
-      addressReceiveServices = ServiceIdentifier.NODE_NONE,
+      addressReceiveServices = ServiceIdentifier.NODE_WITNESS,
       addressReceiveIpAddress = receivingIpAddress,
       addressReceivePort = network.port,
       addressTransServices = ServiceIdentifier.NODE_NETWORK,

--- a/core/src/main/scala/org/bitcoins/core/protocol/tlv/TLV.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/tlv/TLV.scala
@@ -741,9 +741,9 @@ object DLCOfferTLV extends TLVFactory[DLCOfferTLV] {
 
     val contractFlags = iter.take(1).head
     val chainHash = DoubleSha256Digest(iter.take(32))
-    val contractInfo = ContractInfoV0TLV.fromBytes(iter.current)
+    val contractInfo = ContractInfoTLV.fromBytes(iter.current)
     iter.skip(contractInfo)
-    val oracleInfo = OracleInfoV0TLV.fromBytes(iter.current)
+    val oracleInfo = OracleInfoTLV.fromBytes(iter.current)
     iter.skip(oracleInfo)
     val fundingPubKey = ECPublicKey(iter.take(33))
     val payoutSPK = iter.takeSPK()

--- a/db-commons/src/main/resources/reference.conf
+++ b/db-commons/src/main/resources/reference.conf
@@ -156,6 +156,13 @@ bitcoin-s {
 
 akka {
 
+  # Let Cli commands take 30 seconds
+  http.server.request-timeout = 30s
+
+  # Can parse 20MBs
+  http.server.parsing.max-content-length = 20m
+  http.client.parsing.max-content-length = 20m
+
   # Loggers to register at boot time (akka.event.Logging$DefaultLogger logs
   # to STDOUT)
   loggers = ["akka.event.slf4j.Slf4jLogger"]

--- a/dlc-test/src/test/scala/org/bitcoins/dlc/DLCClientIntegrationTest.scala
+++ b/dlc-test/src/test/scala/org/bitcoins/dlc/DLCClientIntegrationTest.scala
@@ -361,7 +361,7 @@ class DLCClientIntegrationTest extends BitcoindRpcTest {
       builder: DLCTxBuilder): Future[Assertion] = {
     val fundingTx = outcome.fundingTx
     val closingTx = outcome match {
-      case ExecutedDLCOutcome(_, cet)    => cet
+      case ExecutedDLCOutcome(_, cet, _) => cet
       case RefundDLCOutcome(_, refundTx) => refundTx
     }
 

--- a/dlc-test/src/test/scala/org/bitcoins/dlc/DLCClientTest.scala
+++ b/dlc-test/src/test/scala/org/bitcoins/dlc/DLCClientTest.scala
@@ -377,14 +377,11 @@ class DLCClientTest extends BitcoinSAsyncTest {
           val fullDigits =
             CETCalculator.decompose(outcomeIndex, base = 10, numOutcomes)
 
-          val digits = outcomes.find {
-            case UnsignedNumericOutcome(digits) => fullDigits.startsWith(digits)
-            case EnumOutcome(_)                 => fail("Expected MultiDigit outcome")
-          } match {
-            case Some(UnsignedNumericOutcome(digits)) => digits
-            case Some(EnumOutcome(_)) | None =>
-              fail(s"Couldn't find outcome for $outcomeIndex")
-          }
+          val digits =
+            CETCalculator.searchForNumericOutcome(fullDigits, outcomes) match {
+              case Some(UnsignedNumericOutcome(digits)) => digits
+              case None                                 => fail(s"Couldn't find outcome for $outcomeIndex")
+            }
 
           digits.zip(preCommittedKs.take(digits.length)).map {
             case (digit, kValue) =>
@@ -673,14 +670,9 @@ class DLCClientTest extends BitcoinSAsyncTest {
       setupDLC(numDigits, isMultiDigit = true).flatMap {
         case (acceptSetup, dlcAccept, offerSetup, dlcOffer, outcomes) =>
           runTestsForParam(outcomesToTest) { outcomeToTest =>
-            val outcome = outcomes
-              .find {
-                case UnsignedNumericOutcome(digits) =>
-                  outcomeToTest.startsWith(digits)
-                case _: EnumOutcome => false
-              }
+            val outcome = CETCalculator
+              .searchForNumericOutcome(outcomeToTest, outcomes)
               .get
-              .asInstanceOf[UnsignedNumericOutcome]
 
             val oracleSigs = outcome.digits
               .zip(preCommittedKs.take(numDigits))

--- a/dlc-test/src/test/scala/org/bitcoins/dlc/DLCClientTest.scala
+++ b/dlc-test/src/test/scala/org/bitcoins/dlc/DLCClientTest.scala
@@ -291,7 +291,7 @@ class DLCClientTest extends BitcoinSAsyncTest {
     )
 
     outcome match {
-      case ExecutedDLCOutcome(fundingTx, cet) =>
+      case ExecutedDLCOutcome(fundingTx, cet, _) =>
         DLCFeeTestUtil.validateFees(dlcOffer.dlcTxBuilder,
                                     fundingTx,
                                     cet,

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCDAOTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCDAOTest.scala
@@ -4,6 +4,7 @@ import org.bitcoins.core.api.wallet.db.TransactionDbHelper
 import org.bitcoins.core.currency.Satoshis
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.script.EmptyScriptPubKey
+import org.bitcoins.core.protocol.tlv.{EnumOutcome, UnsignedNumericOutcome}
 import org.bitcoins.core.protocol.transaction.{
   TransactionOutPoint,
   TransactionOutput
@@ -121,18 +122,42 @@ class DLCDAOTest extends BitcoinSWalletTest with DLCDAOFixture {
       } yield assert(readInput.size == 2)
   }
 
-  it should "correctly insert CET signatures into the database" in { daos =>
-    val dlcDAO = daos.dlcDAO
-    val sigsDAO = daos.dlcSigsDAO
+  it should "correctly insert enum outcome CET signatures into the database" in {
+    daos =>
+      val dlcDAO = daos.dlcDAO
+      val sigsDAO = daos.dlcSigsDAO
 
-    val sig = DLCCETSignatureDb(
-      paramHash = paramHash,
-      isInitiator = true,
-      outcome = DLCWalletUtil.winStr,
-      signature = ECAdaptorSignature.dummy
-    )
+      val sig = DLCCETSignatureDb(
+        paramHash = paramHash,
+        isInitiator = true,
+        outcome = EnumOutcome(DLCWalletUtil.winStr),
+        signature = ECAdaptorSignature.dummy
+      )
 
-    verifyDatabaseInsertion(sig, (sig.paramHash, sig.outcome), sigsDAO, dlcDAO)
+      verifyDatabaseInsertion(sig,
+                              (sig.paramHash, sig.outcome),
+                              sigsDAO,
+                              dlcDAO)
+  }
+
+  it should "correctly insert unsigned numeric outcome CET signatures into the database" in {
+    daos =>
+      val dlcDAO = daos.dlcDAO
+      val sigsDAO = daos.dlcSigsDAO
+
+      val outcomes = 0.to(100).toVector
+
+      val sig = DLCCETSignatureDb(
+        paramHash = paramHash,
+        isInitiator = true,
+        outcome = UnsignedNumericOutcome(outcomes),
+        signature = ECAdaptorSignature.dummy
+      )
+
+      verifyDatabaseInsertion(sig,
+                              (sig.paramHash, sig.outcome),
+                              sigsDAO,
+                              dlcDAO)
   }
 
   it should "correctly find CET signatures by eventId" in { daos =>
@@ -143,13 +168,13 @@ class DLCDAOTest extends BitcoinSWalletTest with DLCDAOFixture {
       DLCCETSignatureDb(
         paramHash = paramHash,
         isInitiator = true,
-        outcome = DLCWalletUtil.winStr,
+        outcome = EnumOutcome(DLCWalletUtil.winStr),
         signature = ECAdaptorSignature.dummy
       ),
       DLCCETSignatureDb(
         paramHash = paramHash,
         isInitiator = false,
-        outcome = DLCWalletUtil.loseStr,
+        outcome = EnumOutcome(DLCWalletUtil.loseStr),
         signature = ECAdaptorSignature.dummy
       )
     )

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCMultiNonceExecutionTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCMultiNonceExecutionTest.scala
@@ -1,0 +1,138 @@
+package org.bitcoins.dlc.wallet
+
+import org.bitcoins.commons.jsonmodels.dlc.DLCMessage.{
+  ContractInfo,
+  MultiNonceContractInfo,
+  SingleNonceContractInfo
+}
+import org.bitcoins.commons.jsonmodels.dlc.DLCState
+import org.bitcoins.commons.jsonmodels.dlc.DLCStatus.{Claimed, RemoteClaimed}
+import org.bitcoins.core.currency.Satoshis
+import org.bitcoins.crypto.{CryptoUtil, SchnorrDigitalSignature}
+import org.bitcoins.testkit.wallet.DLCWalletUtil._
+import org.bitcoins.testkit.wallet.{BitcoinSDualWalletTest, DLCWalletUtil}
+import org.scalatest.FutureOutcome
+
+class DLCMultiNonceExecutionTest extends BitcoinSDualWalletTest {
+  type FixtureParam = (InitializedDLCWallet, InitializedDLCWallet)
+
+  override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
+    withDualDLCWallets(test, multiNonce = true)
+  }
+
+  behavior of "DLCWallet"
+
+  def getSigs(contractInfo: ContractInfo): (
+      Vector[SchnorrDigitalSignature],
+      Vector[SchnorrDigitalSignature]) = {
+    val multiNonceContractInfo: MultiNonceContractInfo = contractInfo match {
+      case info: MultiNonceContractInfo => info
+      case _: SingleNonceContractInfo =>
+        throw new IllegalArgumentException("Unexpected Contract Info")
+    }
+
+    val initiatorWinVec =
+      multiNonceContractInfo.outcomeVec
+        .maxBy(_._2.toLong)
+        ._1
+
+    val kValues = DLCWalletUtil.kValues.take(initiatorWinVec.size)
+
+    val initiatorWinSigs = initiatorWinVec.zip(kValues).map {
+      case (num, kValue) =>
+        DLCWalletUtil.oraclePrivKey
+          .schnorrSignWithNonce(CryptoUtil.sha256(num.toString).bytes, kValue)
+    }
+
+    val recipientWinVec =
+      multiNonceContractInfo.outcomeVec.find(_._2 == Satoshis.zero).get._1
+
+    val kValues2 = DLCWalletUtil.kValues.take(recipientWinVec.size)
+
+    val recipientWinSigs = recipientWinVec.zip(kValues2).map {
+      case (num, kValue) =>
+        DLCWalletUtil.oraclePrivKey
+          .schnorrSignWithNonce(CryptoUtil.sha256(num.toString).bytes, kValue)
+    }
+
+    (initiatorWinSigs, recipientWinSigs)
+  }
+
+  it must "execute as the initiator" in { wallets =>
+    for {
+      contractId <- getContractId(wallets._1.wallet)
+      offer <- getInitialOffer(wallets._1.wallet)
+      (sigs, _) = getSigs(offer.contractInfo)
+      func = (wallet: DLCWallet) => wallet.executeDLC(contractId, sigs)
+
+      result <- dlcExecutionTest(wallets = wallets,
+                                 asInitiator = true,
+                                 func = func,
+                                 expectedOutputs = 1)
+
+      _ = assert(result)
+
+      dlcDbAOpt <- wallets._1.wallet.dlcDAO.findByContractId(contractId)
+      dlcDbBOpt <- wallets._2.wallet.dlcDAO.findByContractId(contractId)
+
+      paramHash = dlcDbAOpt.get.paramHash
+
+      statusAOpt <- wallets._1.wallet.findDLC(paramHash)
+      statusBOpt <- wallets._2.wallet.findDLC(paramHash)
+
+      _ = {
+        (statusAOpt, statusBOpt) match {
+          case (Some(statusA: Claimed), Some(statusB: RemoteClaimed)) =>
+//     fixme       assert(statusA.oracleSig == statusB.oracleSig)
+          case (_, _) => fail()
+        }
+      }
+    } yield {
+      (dlcDbAOpt, dlcDbBOpt) match {
+        case (Some(dlcA), Some(dlcB)) =>
+          assert(dlcA.state == DLCState.Claimed)
+          assert(dlcB.state == DLCState.RemoteClaimed)
+        case (_, _) => fail()
+      }
+    }
+  }
+
+  it must "execute as the recipient" in { wallets =>
+    for {
+      contractId <- getContractId(wallets._1.wallet)
+      offer <- getInitialOffer(wallets._2.wallet)
+      (_, sigs) = getSigs(offer.contractInfo)
+      func = (wallet: DLCWallet) => wallet.executeDLC(contractId, sigs)
+
+      result <- dlcExecutionTest(wallets = wallets,
+                                 asInitiator = false,
+                                 func = func,
+                                 expectedOutputs = 1)
+
+      _ = assert(result)
+
+      dlcDbAOpt <- wallets._1.wallet.dlcDAO.findByContractId(contractId)
+      dlcDbBOpt <- wallets._2.wallet.dlcDAO.findByContractId(contractId)
+
+      paramHash = dlcDbAOpt.get.paramHash
+
+      statusAOpt <- wallets._1.wallet.findDLC(paramHash)
+      statusBOpt <- wallets._2.wallet.findDLC(paramHash)
+
+      _ = {
+        (statusAOpt, statusBOpt) match {
+          case (Some(statusA: RemoteClaimed), Some(statusB: Claimed)) =>
+//     fixme       assert(statusA.oracleSig == statusB.oracleSig)
+          case (_, _) => fail()
+        }
+      }
+    } yield {
+      (dlcDbAOpt, dlcDbBOpt) match {
+        case (Some(dlcA), Some(dlcB)) =>
+          assert(dlcA.state == DLCState.RemoteClaimed)
+          assert(dlcB.state == DLCState.Claimed)
+        case (_, _) => fail()
+      }
+    }
+  }
+}

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/WalletDLCSetupTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/WalletDLCSetupTest.scala
@@ -39,8 +39,10 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
       )
       paramHash = offer.paramHash
       dlcA1Opt <- walletA.dlcDAO.read(paramHash)
+      find1 <- walletA.findDLC(paramHash)
       _ = {
         assert(dlcA1Opt.isDefined)
+        assert(find1.isDefined)
         assert(dlcA1Opt.get.state == DLCState.Offered)
         assert(offer.oracleInfo == offerData.oracleInfo)
         assert(offer.contractInfo == offerData.contractInfo)

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/WalletDLCSetupTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/WalletDLCSetupTest.scala
@@ -3,7 +3,7 @@ package org.bitcoins.dlc.wallet
 import org.bitcoins.commons.jsonmodels.dlc.DLCMessage._
 import org.bitcoins.commons.jsonmodels.dlc._
 import org.bitcoins.core.currency.Satoshis
-import org.bitcoins.core.protocol.tlv.EnumOutcome
+import org.bitcoins.core.protocol.BigSizeUInt
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.crypto._
 import org.bitcoins.testkit.wallet.DLCWalletUtil._
@@ -22,20 +22,115 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
 
   behavior of "DLCWallet"
 
+  def testNegotiate(
+      fundedDLCWallets: (FundedDLCWallet, FundedDLCWallet),
+      offerData: DLCOffer): Future[Assertion] = {
+    val walletA = fundedDLCWallets._1.wallet
+    val walletB = fundedDLCWallets._2.wallet
+
+    for {
+      offer <- walletA.createDLCOffer(
+        offerData.oracleInfo,
+        offerData.contractInfo,
+        offerData.totalCollateral,
+        Some(offerData.feeRate),
+        offerData.timeouts.contractMaturity.toUInt32,
+        offerData.timeouts.contractTimeout.toUInt32
+      )
+      paramHash = offer.paramHash
+      dlcA1Opt <- walletA.dlcDAO.read(paramHash)
+      _ = {
+        assert(dlcA1Opt.isDefined)
+        assert(dlcA1Opt.get.state == DLCState.Offered)
+        assert(offer.oracleInfo == offerData.oracleInfo)
+        assert(offer.contractInfo == offerData.contractInfo)
+        assert(offer.totalCollateral == offerData.totalCollateral)
+        assert(offer.feeRate == offerData.feeRate)
+        assert(offer.timeouts == offerData.timeouts)
+        assert(offer.fundingInputs.nonEmpty)
+        assert(offer.changeAddress.value.nonEmpty)
+      }
+
+      accept <- walletB.acceptDLCOffer(offer)
+      dlcB1Opt <- walletB.dlcDAO.read(paramHash)
+      _ = {
+        assert(dlcB1Opt.isDefined)
+        assert(dlcB1Opt.get.state == DLCState.Accepted)
+        assert(accept.fundingInputs.nonEmpty)
+        assert(
+          accept.fundingInputs
+            .map(_.output.value)
+            .sum >= accept.totalCollateral)
+        assert(
+          accept.totalCollateral == offer.contractInfo.max - offer.totalCollateral)
+        assert(accept.changeAddress.value.nonEmpty)
+      }
+
+      sign <- walletA.signDLC(accept)
+      dlcA2Opt <- walletA.dlcDAO.read(paramHash)
+      _ = {
+        assert(dlcA2Opt.isDefined)
+        assert(dlcA2Opt.get.state == DLCState.Signed)
+        assert(sign.fundingSigs.length == offerData.fundingInputs.size)
+      }
+
+      dlcDb <- walletB.addDLCSigs(sign)
+      _ = assert(dlcDb.state == DLCState.Signed)
+      outcomeSigs <- walletB.dlcSigsDAO.findByParamHash(offer.paramHash)
+
+      refundSigsA <-
+        walletA.dlcRefundSigDAO
+          .findByParamHash(paramHash)
+          .map(_.map(_.refundSig))
+      refundSigsB <-
+        walletB.dlcRefundSigDAO
+          .findByParamHash(paramHash)
+          .map(_.map(_.refundSig))
+
+      walletAChange <- walletA.addressDAO.read(offer.changeAddress)
+      walletAFinal <- walletA.addressDAO.read(offer.pubKeys.payoutAddress)
+
+      walletBChange <- walletB.addressDAO.read(accept.changeAddress)
+      walletBFinal <- walletB.addressDAO.read(accept.pubKeys.payoutAddress)
+
+    } yield {
+      assert(dlcDb.contractIdOpt.get == sign.contractId)
+
+      assert(refundSigsA.size == 2)
+      assert(refundSigsA.forall(refundSigsB.contains))
+
+      assert(sign.cetSigs.outcomeSigs.forall(sig =>
+        outcomeSigs.exists(dbSig => (dbSig.outcome, dbSig.signature) == sig)))
+
+      // Test that the Addresses are in the wallet's database
+      assert(walletAChange.isDefined)
+      assert(walletAFinal.isDefined)
+      assert(walletBChange.isDefined)
+      assert(walletBFinal.isDefined)
+    }
+  }
+
   it must "correctly negotiate a dlc" in {
-    FundedDLCWallets: (FundedDLCWallet, FundedDLCWallet) =>
-      val walletA = FundedDLCWallets._1.wallet
-      val walletB = FundedDLCWallets._2.wallet
+    fundedDLCWallets: (FundedDLCWallet, FundedDLCWallet) =>
+      testNegotiate(fundedDLCWallets, DLCWalletUtil.sampleDLCOffer)
+  }
+
+  it must "correctly negotiate a dlc with a multi-nonce oracle info" in {
+    fundedDLCWallets: (FundedDLCWallet, FundedDLCWallet) =>
+      testNegotiate(fundedDLCWallets, DLCWalletUtil.sampleMultiNonceDLCOffer)
+  }
+
+  it must "correctly negotiate a dlc using TLVs" in {
+    fundedDLCWallets: (FundedDLCWallet, FundedDLCWallet) =>
+      val walletA = fundedDLCWallets._1.wallet
+      val walletB = fundedDLCWallets._2.wallet
 
       val offerData = DLCWalletUtil.sampleDLCOffer
-      val paramHash = DLCMessage.calcParamHash(offerData.oracleInfo,
-                                               offerData.contractInfo,
-                                               offerData.timeouts)
 
       for {
         offer <- walletA.createDLCOffer(
           offerData.oracleInfo,
-          offerData.contractInfo,
+          offerData.contractInfo.toTLV,
           offerData.totalCollateral,
           Some(offerData.feeRate),
           offerData.timeouts.contractMaturity.toUInt32,
@@ -55,7 +150,7 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
           assert(offer.changeAddress.value.nonEmpty)
         }
 
-        accept <- walletB.acceptDLCOffer(offer)
+        accept <- walletB.acceptDLCOffer(offer.toTLV)
         dlcB1Opt <- walletB.dlcDAO.read(paramHash)
         _ = {
           assert(dlcB1Opt.isDefined)
@@ -70,7 +165,7 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
           assert(accept.changeAddress.value.nonEmpty)
         }
 
-        sign <- walletA.signDLC(accept)
+        sign <- walletA.signDLC(accept.toTLV)
         dlcA2Opt <- walletA.dlcDAO.read(paramHash)
         _ = {
           assert(dlcA2Opt.isDefined)
@@ -78,7 +173,7 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
           assert(sign.fundingSigs.length == offerData.fundingInputs.size)
         }
 
-        dlcDb <- walletB.addDLCSigs(sign)
+        dlcDb <- walletB.addDLCSigs(sign.toTLV)
         _ = assert(dlcDb.state == DLCState.Signed)
         outcomeSigs <- walletB.dlcSigsDAO.findByParamHash(offer.paramHash)
 
@@ -104,8 +199,7 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
         assert(refundSigsA.forall(refundSigsB.contains))
 
         assert(sign.cetSigs.outcomeSigs.forall(sig =>
-          outcomeSigs.exists(dbSig =>
-            (EnumOutcome(dbSig.outcome), dbSig.signature) == sig)))
+          outcomeSigs.exists(dbSig => (dbSig.outcome, dbSig.signature) == sig)))
 
         // Test that the Addresses are in the wallet's database
         assert(walletAChange.isDefined)
@@ -242,12 +336,28 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
       val walletA = FundedDLCWallets._1.wallet
       val walletB = FundedDLCWallets._2.wallet
 
-      val winHash = CryptoUtil.sha256("Democrat_win")
-      val loseHash = CryptoUtil.sha256("Republican_win")
-      val drawHash = CryptoUtil.sha256("other")
-      val contractInfo = ContractInfo(winHash.bytes ++ Satoshis(
-        10000).bytes ++ loseHash.bytes ++ Satoshis.zero.bytes ++ drawHash.bytes ++ Satoshis(
-        5000).bytes)
+      val winStr = "Democrat_win"
+      val loseStr = "Republican_win"
+      val drawStr = "other"
+
+      val betSize = 10000
+
+      lazy val contractInfo: ContractInfo = {
+        val winBytes = CryptoUtil.serializeForHash(winStr)
+        val loseBytes = CryptoUtil.serializeForHash(loseStr)
+        val drawBytes = CryptoUtil.serializeForHash(drawStr)
+
+        ContractInfo(
+          BigSizeUInt.calcFor(winBytes).bytes ++
+            winBytes ++
+            Satoshis(betSize).bytes ++
+            BigSizeUInt.calcFor(loseBytes).bytes ++
+            loseBytes ++
+            Satoshis.zero.bytes ++
+            BigSizeUInt.calcFor(drawBytes).bytes ++
+            drawBytes ++
+            Satoshis(betSize / 2).bytes)
+      }
 
       val oraclePubKey = SchnorrPublicKey(
         "156c7d1c7922f0aa1168d9e21ac77ea88bbbe05e24e70a08bbe0519778f2e5da")
@@ -332,7 +442,7 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
 
           assert(sign.cetSigs.outcomeSigs.forall(sig =>
             outcomeSigs.exists(dbSig =>
-              (EnumOutcome(dbSig.outcome), dbSig.signature) == sig)))
+              (dbSig.outcome, dbSig.signature) == sig)))
           // Test that the Addresses are in the wallet's database
           assert(walletAChange.isDefined)
           assert(walletAFinal.isDefined)

--- a/dlc-wallet/src/main/resources/postgresql/dlc/migration/V1__dlc_db_baseline.sql
+++ b/dlc-wallet/src/main/resources/postgresql/dlc/migration/V1__dlc_db_baseline.sql
@@ -7,7 +7,8 @@ CREATE TABLE "wallet_dlcs"
     "is_initiator"     BOOLEAN NOT NULL,
     "account"          TEXT    NOT NULL,
     "key_index"        INTEGER NOT NULL,
-    "oracle_sig"       TEXT,
+    "oracle_sigs"      TEXT,
+    "funding_outpoint" TEXT,
     "funding_tx_id"    TEXT,
     "closing_tx_id"    TEXT,
     constraint "pk_dlc" primary key ("param_hash")
@@ -18,8 +19,7 @@ CREATE TABLE "wallet_dlc_offers"
 (
     "param_hash"        VARCHAR(254) NOT NULL UNIQUE,
     "temp_contract_id"  TEXT         NOT NULL UNIQUE,
-    "oracle_pub_key"    TEXT         NOT NULL,
-    "oracle_r_value"    TEXT         NOT NULL,
+    "oracle_info_tlv"   TEXT         NOT NULL,
     "contract_info"     TEXT         NOT NULL,
     "contract_maturity" TEXT         NOT NULL,
     "contract_timeout"  TEXT         NOT NULL,
@@ -62,10 +62,10 @@ CREATE TABLE "wallet_dlc_funding_inputs"
 
 CREATE TABLE "wallet_dlc_cet_sigs"
 (
-    "param_hash"   TEXT NOT NULL,
-    "outcome_hash" TEXT NOT NULL,
-    "signature"    TEXT NOT NULL,
-    constraint "pk_dlc_cet_sigs" primary key ("param_hash", "outcome_hash"),
+    "param_hash"   TEXT    NOT NULL,
+    "is_initiator" INTEGER NOT NULL,
+    "outcome"      TEXT    NOT NULL,
+    "signature"    TEXT    NOT NULL,
     constraint "fk_param_hash" foreign key ("param_hash") references "wallet_dlcs" ("param_hash") on update NO ACTION on delete NO ACTION
 );
 

--- a/dlc-wallet/src/main/resources/postgresql/dlc/migration/V2__add_init_to_cet_sig_db.sql
+++ b/dlc-wallet/src/main/resources/postgresql/dlc/migration/V2__add_init_to_cet_sig_db.sql
@@ -1,2 +1,0 @@
-ALTER TABLE "wallet_dlc_cet_sigs" ADD COLUMN is_initiator BOOLEAN NOT NULL DEFAULT false;
-ALTER TABLE "wallet_dlcs" ADD COLUMN "funding_outpoint" VARCHAR(254);

--- a/dlc-wallet/src/main/resources/postgresql/dlc/migration/V2__add_outcome.sql
+++ b/dlc-wallet/src/main/resources/postgresql/dlc/migration/V2__add_outcome.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "wallet_dlcs" ADD COLUMN "outcome" TEXT;

--- a/dlc-wallet/src/main/resources/sqlite/dlc/migration/V1__dlc_db_baseline.sql
+++ b/dlc-wallet/src/main/resources/sqlite/dlc/migration/V1__dlc_db_baseline.sql
@@ -7,7 +7,8 @@ CREATE TABLE "wallet_dlcs"
     "is_initiator"     INTEGER      NOT NULL,
     "account"          VARCHAR(254) NOT NULL,
     "key_index"        INTEGER      NOT NULL,
-    "oracle_sig"       VARCHAR(254),
+    "oracle_sigs"      VARCHAR(254),
+    "funding_outpoint" VARCHAR(254),
     "funding_tx_id"    VARCHAR(254),
     "closing_tx_id"    VARCHAR(254)
 );
@@ -17,8 +18,7 @@ CREATE TABLE "wallet_dlc_offers"
 (
     "param_hash"        VARCHAR(254) NOT NULL UNIQUE,
     "temp_contract_id"  VARCHAR(254) NOT NULL UNIQUE,
-    "oracle_pub_key"    VARCHAR(254) NOT NULL,
-    "oracle_r_value"    VARCHAR(254) NOT NULL,
+    "oracle_info_tlv"   VARCHAR(254) NOT NULL,
     "contract_info"     VARCHAR(254) NOT NULL,
     "contract_maturity" VARCHAR(254) NOT NULL,
     "contract_timeout"  VARCHAR(254) NOT NULL,
@@ -57,7 +57,8 @@ CREATE TABLE "wallet_dlc_funding_inputs"
 CREATE TABLE "wallet_dlc_cet_sigs"
 (
     "param_hash"   VARCHAR(254) NOT NULL,
-    "outcome_hash" VARCHAR(254) NOT NULL,
+    "is_initiator" INTEGER      NOT NULL,
+    "outcome"      VARCHAR(254) NOT NULL,
     "signature"    VARCHAR(254) NOT NULL,
     constraint "fk_param_hash" foreign key ("param_hash") references "wallet_dlcs" ("param_hash") on update NO ACTION on delete NO ACTION
 );

--- a/dlc-wallet/src/main/resources/sqlite/dlc/migration/V2__add_init_to_cet_sig_db.sql
+++ b/dlc-wallet/src/main/resources/sqlite/dlc/migration/V2__add_init_to_cet_sig_db.sql
@@ -1,2 +1,0 @@
-ALTER TABLE `wallet_dlc_cet_sigs` ADD COLUMN `is_initiator` INTEGER NOT NULL DEFAULT false;
-ALTER TABLE "wallet_dlcs" ADD COLUMN "funding_outpoint" VARCHAR(254);

--- a/dlc-wallet/src/main/resources/sqlite/dlc/migration/V2__add_outcome.sql
+++ b/dlc-wallet/src/main/resources/sqlite/dlc/migration/V2__add_outcome.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "wallet_dlcs" ADD COLUMN "outcome" TEXT;

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -1426,6 +1426,10 @@ abstract class DLCWallet extends Wallet with AnyDLCHDWalletApi {
               dlcDb.outcomeOpt.get
             )
           case DLCState.RemoteClaimed =>
+            val oracleSigs = dlcDb.oracleSigsOpt.get
+            require(oracleSigs.size == 1,
+                    "Remote claimed should only have one oracle sig")
+
             SerializedRemoteClaimed(
               paramHash,
               dlcDb.isInitiator,
@@ -1439,7 +1443,7 @@ abstract class DLCWallet extends Wallet with AnyDLCHDWalletApi {
               localCollateral,
               dlcDb.fundingTxIdOpt.get,
               dlcDb.closingTxIdOpt.get,
-              dlcDb.oracleSigsOpt.get,
+              oracleSigs.head,
               dlcDb.outcomeOpt.get
             )
           case DLCState.Refunded =>

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWalletApi.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWalletApi.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.dlc.wallet
 
 import org.bitcoins.commons.jsonmodels.dlc.DLCMessage._
-import org.bitcoins.commons.jsonmodels.dlc.DLCStatus
+import org.bitcoins.commons.jsonmodels.dlc.{DLCStatus, SerializedDLCStatus}
 import org.bitcoins.core.api.wallet._
 import org.bitcoins.core.currency.Satoshis
 import org.bitcoins.core.number.UInt32
@@ -83,7 +83,10 @@ trait DLCWalletApi { self: WalletApi =>
   /** Creates the refund transaction for the given contractId, does not broadcast it */
   def executeDLCRefund(contractId: ByteVector): Future[Transaction]
 
-  def listDLCs(): Future[Vector[DLCStatus]]
+  def listDLCs(): Future[Vector[SerializedDLCStatus]]
+
+  def findSerializedDLC(
+      paramHash: Sha256DigestBE): Future[Option[SerializedDLCStatus]]
 
   def findDLC(paramHash: Sha256DigestBE): Future[Option[DLCStatus]]
 }

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWalletApi.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWalletApi.scala
@@ -2,14 +2,10 @@ package org.bitcoins.dlc.wallet
 
 import org.bitcoins.commons.jsonmodels.dlc.DLCMessage._
 import org.bitcoins.commons.jsonmodels.dlc.DLCStatus
-import org.bitcoins.core.api.wallet.{
-  HDWalletApi,
-  NeutrinoWalletApi,
-  SpvWalletApi,
-  WalletApi
-}
+import org.bitcoins.core.api.wallet._
 import org.bitcoins.core.currency.Satoshis
 import org.bitcoins.core.number.UInt32
+import org.bitcoins.core.protocol.tlv._
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.wallet.fee.FeeUnit
 import org.bitcoins.crypto.{SchnorrDigitalSignature, Sha256DigestBE}
@@ -19,6 +15,22 @@ import scodec.bits.ByteVector
 import scala.concurrent.Future
 
 trait DLCWalletApi { self: WalletApi =>
+
+  def createDLCOffer(
+      oracleInfo: OracleInfo,
+      contractInfoTLV: ContractInfoTLV,
+      collateral: Satoshis,
+      feeRateOpt: Option[FeeUnit],
+      locktime: UInt32,
+      refundLT: UInt32): Future[DLCOffer] = {
+    val contractInfo = ContractInfo.fromTLV(contractInfoTLV)
+    createDLCOffer(oracleInfo,
+                   contractInfo,
+                   collateral,
+                   feeRateOpt,
+                   locktime,
+                   refundLT)
+  }
 
   def createDLCOffer(
       oracleInfo: OracleInfo,
@@ -39,9 +51,17 @@ trait DLCWalletApi { self: WalletApi =>
     )
   }
 
+  def acceptDLCOffer(dlcOfferTLV: DLCOfferTLV): Future[DLCAccept] = {
+    acceptDLCOffer(DLCOffer.fromTLV(dlcOfferTLV))
+  }
+
   def acceptDLCOffer(dlcOffer: DLCOffer): Future[DLCAccept]
 
+  def signDLC(acceptTLV: DLCAcceptTLV): Future[DLCSign]
+
   def signDLC(accept: DLCAccept): Future[DLCSign]
+
+  def addDLCSigs(signTLV: DLCSignTLV): Future[DLCDb]
 
   def addDLCSigs(sigs: DLCSign): Future[DLCDb]
 
@@ -52,7 +72,13 @@ trait DLCWalletApi { self: WalletApi =>
   /** Creates the CET for the given contractId and oracle signature, does not broadcast it */
   def executeDLC(
       contractId: ByteVector,
-      oracleSig: SchnorrDigitalSignature): Future[Transaction]
+      oracleSig: SchnorrDigitalSignature): Future[Transaction] =
+    executeDLC(contractId, Vector(oracleSig))
+
+  /** Creates the CET for the given contractId and oracle signature, does not broadcast it */
+  def executeDLC(
+      contractId: ByteVector,
+      oracleSigs: Vector[SchnorrDigitalSignature]): Future[Transaction]
 
   /** Creates the refund transaction for the given contractId, does not broadcast it */
   def executeDLCRefund(contractId: ByteVector): Future[Transaction]

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCCETSignatureDAO.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCCETSignatureDAO.scala
@@ -57,6 +57,15 @@ case class DLCCETSignatureDAO()(implicit
   }
 
   def findByParamHash(
+      paramHash: Sha256DigestBE,
+      isInit: Boolean): Future[Vector[DLCCETSignatureDb]] = {
+    val q = table
+      .filter(_.paramHash === paramHash)
+      .filter(_.isInitiator === isInit)
+    safeDatabase.run(q.result).map(_.toVector)
+  }
+
+  def findByParamHash(
       paramHash: Sha256Digest): Future[Vector[DLCCETSignatureDb]] =
     findByParamHash(paramHash.flip)
 

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCCETSignatureDAO.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCCETSignatureDAO.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.dlc.wallet.models
 
+import org.bitcoins.core.protocol.tlv.DLCOutcomeType
 import org.bitcoins.crypto.{ECAdaptorSignature, Sha256Digest, Sha256DigestBE}
 import org.bitcoins.db.{CRUD, SlickUtil}
 import org.bitcoins.dlc.wallet.DLCAppConfig
@@ -10,8 +11,8 @@ import scala.concurrent.{ExecutionContext, Future}
 case class DLCCETSignatureDAO()(implicit
     val ec: ExecutionContext,
     override val appConfig: DLCAppConfig)
-    extends CRUD[DLCCETSignatureDb, (Sha256DigestBE, String)]
-    with SlickUtil[DLCCETSignatureDb, (Sha256DigestBE, String)] {
+    extends CRUD[DLCCETSignatureDb, (Sha256DigestBE, DLCOutcomeType)]
+    with SlickUtil[DLCCETSignatureDb, (Sha256DigestBE, DLCOutcomeType)] {
   private val mappers = new org.bitcoins.db.DbCommonsColumnMappers(profile)
   import mappers._
   import profile.api._
@@ -27,16 +28,14 @@ case class DLCCETSignatureDAO()(implicit
       ts: Vector[DLCCETSignatureDb]): Future[Vector[DLCCETSignatureDb]] =
     createAllNoAutoInc(ts, safeDatabase)
 
-  override protected def findByPrimaryKeys(
-      ids: Vector[(Sha256DigestBE, String)]): Query[
-    DLCCETSignatureTable,
-    DLCCETSignatureDb,
-    Seq] =
+  override protected def findByPrimaryKeys(ids: Vector[(
+      Sha256DigestBE,
+      DLCOutcomeType)]): Query[DLCCETSignatureTable, DLCCETSignatureDb, Seq] =
     table
       .filter(_.paramHash.inSet(ids.map(_._1)))
       .filter(_.outcome.inSet(ids.map(_._2)))
 
-  override def findByPrimaryKey(id: (Sha256DigestBE, String)): Query[
+  override def findByPrimaryKey(id: (Sha256DigestBE, DLCOutcomeType)): Query[
     DLCCETSignatureTable,
     DLCCETSignatureDb,
     Seq] = {
@@ -68,7 +67,7 @@ case class DLCCETSignatureDAO()(implicit
 
     def isInitiator: Rep[Boolean] = column("is_initiator")
 
-    def outcome: Rep[String] = column("outcome")
+    def outcome: Rep[DLCOutcomeType] = column("outcome")
 
     def signature: Rep[ECAdaptorSignature] = column("signature")
 
@@ -77,7 +76,8 @@ case class DLCCETSignatureDAO()(implicit
                                                       DLCCETSignatureDb.unapply)
 
     def primaryKey: PrimaryKey =
-      primaryKey(name = "pk_dlc_cet_sigs", sourceColumns = (paramHash, outcome))
+      primaryKey(name = "pk_dlc_cet_sigs",
+                 sourceColumns = (paramHash, isInitiator, outcome))
 
     def fk: ForeignKeyQuery[_, DLCDb] =
       foreignKey("fk_param_hash",

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCCETSignatureDb.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCCETSignatureDb.scala
@@ -1,11 +1,12 @@
 package org.bitcoins.dlc.wallet.models
 
+import org.bitcoins.core.protocol.tlv.DLCOutcomeType
 import org.bitcoins.crypto.{ECAdaptorSignature, Sha256DigestBE}
 
 case class DLCCETSignatureDb(
     paramHash: Sha256DigestBE,
     isInitiator: Boolean,
-    outcome: String,
+    outcome: DLCOutcomeType,
     signature: ECAdaptorSignature) {
-  def toTuple: (String, ECAdaptorSignature) = (outcome, signature)
+  def toTuple: (DLCOutcomeType, ECAdaptorSignature) = (outcome, signature)
 }

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCDAO.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCDAO.scala
@@ -2,6 +2,7 @@ package org.bitcoins.dlc.wallet.models
 
 import org.bitcoins.commons.jsonmodels.dlc.DLCState
 import org.bitcoins.core.hd.HDAccount
+import org.bitcoins.core.protocol.tlv.DLCOutcomeType
 import org.bitcoins.core.protocol.transaction.TransactionOutPoint
 import org.bitcoins.crypto.{
   DoubleSha256DigestBE,
@@ -144,6 +145,8 @@ case class DLCDAO()(implicit
     def closingTxIdOpt: Rep[Option[DoubleSha256DigestBE]] =
       column("closing_tx_id")
 
+    def outcomeOpt: Rep[Option[DLCOutcomeType]] = column("outcome")
+
     def * : ProvenShape[DLCDb] =
       (paramHash,
        tempContractId,
@@ -155,7 +158,8 @@ case class DLCDAO()(implicit
        oracleSigsOpt,
        fundingOutPointOpt,
        fundingTxIdOpt,
-       closingTxIdOpt).<>(DLCDb.tupled, DLCDb.unapply)
+       closingTxIdOpt,
+       outcomeOpt).<>(DLCDb.tupled, DLCDb.unapply)
 
     def primaryKey: PrimaryKey =
       primaryKey(name = "pk_dlc", sourceColumns = paramHash)

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCDAO.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCDAO.scala
@@ -132,8 +132,8 @@ case class DLCDAO()(implicit
 
     def keyIndex: Rep[Int] = column("key_index")
 
-    def oracleSigOpt: Rep[Option[SchnorrDigitalSignature]] =
-      column("oracle_sig")
+    def oracleSigsOpt: Rep[Option[Vector[SchnorrDigitalSignature]]] =
+      column("oracle_sigs")
 
     def fundingOutPointOpt: Rep[Option[TransactionOutPoint]] =
       column("funding_outpoint")
@@ -152,7 +152,7 @@ case class DLCDAO()(implicit
        isInitiator,
        account,
        keyIndex,
-       oracleSigOpt,
+       oracleSigsOpt,
        fundingOutPointOpt,
        fundingTxIdOpt,
        closingTxIdOpt).<>(DLCDb.tupled, DLCDb.unapply)

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCDb.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCDb.scala
@@ -2,6 +2,7 @@ package org.bitcoins.dlc.wallet.models
 
 import org.bitcoins.commons.jsonmodels.dlc.DLCState
 import org.bitcoins.core.hd.HDAccount
+import org.bitcoins.core.protocol.tlv.DLCOutcomeType
 import org.bitcoins.core.protocol.transaction.TransactionOutPoint
 import org.bitcoins.crypto.{
   DoubleSha256DigestBE,
@@ -22,7 +23,8 @@ case class DLCDb(
     oracleSigsOpt: Option[Vector[SchnorrDigitalSignature]],
     fundingOutPointOpt: Option[TransactionOutPoint],
     fundingTxIdOpt: Option[DoubleSha256DigestBE],
-    closingTxIdOpt: Option[DoubleSha256DigestBE]
+    closingTxIdOpt: Option[DoubleSha256DigestBE],
+    outcomeOpt: Option[DLCOutcomeType]
 ) {
 
   def updateState(newState: DLCState): DLCDb = {

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCDb.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCDb.scala
@@ -19,7 +19,7 @@ case class DLCDb(
     isInitiator: Boolean,
     account: HDAccount,
     keyIndex: Int,
-    oracleSigOpt: Option[SchnorrDigitalSignature],
+    oracleSigsOpt: Option[Vector[SchnorrDigitalSignature]],
     fundingOutPointOpt: Option[TransactionOutPoint],
     fundingTxIdOpt: Option[DoubleSha256DigestBE],
     closingTxIdOpt: Option[DoubleSha256DigestBE]

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCOfferDAO.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCOfferDAO.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.dlc.wallet.models
 
-import org.bitcoins.commons.jsonmodels.dlc.DLCMessage.ContractInfo
 import org.bitcoins.core.currency.CurrencyUnit
+import org.bitcoins.core.protocol.tlv.{ContractInfoTLV, OracleInfoTLV}
 import org.bitcoins.core.protocol.{BitcoinAddress, BlockTimeStamp}
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.crypto._
@@ -68,11 +68,9 @@ case class DLCOfferDAO()(implicit
     def tempContractId: Rep[Sha256Digest] =
       column("temp_contract_id", O.Unique)
 
-    def oraclePubKey: Rep[SchnorrPublicKey] = column("oracle_pub_key")
+    def oracleInfoTLV: Rep[OracleInfoTLV] = column("oracle_info_tlv")
 
-    def oracleRValue: Rep[SchnorrNonce] = column("oracle_r_value")
-
-    def contractInfo: Rep[ContractInfo] = column("contract_info")
+    def contractInfoTLV: Rep[ContractInfoTLV] = column("contract_info")
 
     def contractMaturity: Rep[BlockTimeStamp] = column("contract_maturity")
 
@@ -91,9 +89,8 @@ case class DLCOfferDAO()(implicit
     def * : ProvenShape[DLCOfferDb] =
       (paramHash,
        tempContractId,
-       oraclePubKey,
-       oracleRValue,
-       contractInfo,
+       oracleInfoTLV,
+       contractInfoTLV,
        contractMaturity,
        contractTimeout,
        fundingKey,

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCRefundSigDAO.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCRefundSigDAO.scala
@@ -55,6 +55,16 @@ case class DLCRefundSigDAO()(implicit
     safeDatabase.runVec(q.result)
   }
 
+  def findByParamHash(
+      paramHash: Sha256DigestBE,
+      isInit: Boolean): Future[Option[DLCRefundSigDb]] = {
+    val q = table
+      .filter(_.paramHash === paramHash)
+      .filter(_.isInitiator === isInit)
+
+    safeDatabase.runVec(q.result).map(_.headOption)
+  }
+
   def findByParamHash(paramHash: Sha256Digest): Future[Vector[DLCRefundSigDb]] =
     findByParamHash(paramHash.flip)
 

--- a/dlc/src/main/scala/org/bitcoins/dlc/builder/DLCTxBuilder.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/builder/DLCTxBuilder.scala
@@ -19,6 +19,7 @@ import org.bitcoins.core.protocol.transaction.{
 import org.bitcoins.core.protocol.{BitcoinAddress, BlockTimeStamp}
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.crypto._
+import scodec.bits.ByteVector
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -105,6 +106,10 @@ case class DLCTxBuilder(offer: DLCOffer, accept: DLCAcceptWithoutSigs)(implicit
   /** Constructs the unsigned funding transaction */
   lazy val buildFundingTx: Future[Transaction] = {
     fundingTxBuilder.buildFundingTx()
+  }
+
+  lazy val calcContractId: Future[ByteVector] = {
+    buildFundingTx.map(_.txIdBE.bytes.xor(accept.tempContractId.bytes))
   }
 
   private lazy val cetBuilderF = {

--- a/dlc/src/main/scala/org/bitcoins/dlc/execution/DLCExecutor.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/execution/DLCExecutor.scala
@@ -89,7 +89,7 @@ case class DLCExecutor(signer: DLCTxSigner)(implicit ec: ExecutionContext) {
     }
 
     signer.signCET(msg, remoteAdaptorSig, oracleSigs).map { cet =>
-      ExecutedDLCOutcome(fundingTx, cet)
+      ExecutedDLCOutcome(fundingTx, cet, msg)
     }
   }
 

--- a/dlc/src/main/scala/org/bitcoins/dlc/execution/DLCExecutor.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/execution/DLCExecutor.scala
@@ -78,9 +78,7 @@ case class DLCExecutor(signer: DLCTxSigner)(implicit ec: ExecutionContext) {
     ExecutedDLCOutcome] = {
     val SetupDLC(fundingTx, cetInfos, _) = dlcSetup
 
-    val msgOpt =
-      builder.oracleAndContractInfo.allOutcomes.find(msg =>
-        builder.oracleAndContractInfo.verifySigs(msg, oracleSigs))
+    val msgOpt = builder.oracleAndContractInfo.findOutcome(oracleSigs)
     val (msg, remoteAdaptorSig) = msgOpt match {
       case Some(msg) =>
         val cetInfo = cetInfos(msg)

--- a/dlc/src/main/scala/org/bitcoins/dlc/execution/DLCOutcome.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/execution/DLCOutcome.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.dlc.execution
 
+import org.bitcoins.core.protocol.tlv.DLCOutcomeType
 import org.bitcoins.core.protocol.transaction.Transaction
 
 sealed trait DLCOutcome {
@@ -8,7 +9,8 @@ sealed trait DLCOutcome {
 
 case class ExecutedDLCOutcome(
     override val fundingTx: Transaction,
-    cet: Transaction)
+    cet: Transaction,
+    outcome: DLCOutcomeType)
     extends DLCOutcome
 
 case class RefundDLCOutcome(

--- a/dlc/src/main/scala/org/bitcoins/dlc/sign/DLCTxSigner.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/sign/DLCTxSigner.scala
@@ -278,7 +278,9 @@ case class DLCTxSigner(
   /** Creates all of this party's CETSignatures */
   def createCETSigs(): Future[CETSignatures] = {
     val cetSigFs = builder.oracleAndContractInfo.allOutcomes.map { msg =>
-      createRemoteCETSig(msg).map(msg -> _)
+      // Need to wrap in another future so they are all started at once
+      // and do not block each other
+      Future(createRemoteCETSig(msg).map(msg -> _)).flatten
     }
 
     for {

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -37,6 +37,8 @@ object Deps {
     val scalaCollectionCompatV = "2.2.0"
     val pgEmbeddedV = "0.13.3"
 
+    val breezeV = "1.1"
+
     val newMicroPickleV = "0.8.0"
     val newMicroJsonV = newMicroPickleV
 
@@ -122,6 +124,12 @@ object Deps {
                                javaFxMedia,
                                javaFxSwing,
                                javaFxWeb)
+
+    val breeze =
+      "org.scalanlp" %% "breeze" % V.breezeV withSources () withJavadoc ()
+
+    val breezeViz =
+      "org.scalanlp" %% "breeze-viz" % V.breezeV withSources () withJavadoc ()
 
     val playJson =
       "com.typesafe.play" %% "play-json" % V.playv withSources () withJavadoc ()
@@ -317,7 +325,7 @@ object Deps {
       Compile.codehaus
     )
 
-  val gui = List(Compile.scalaFx) ++ Compile.javaFxDeps
+  val gui = List(Compile.breezeViz, Compile.scalaFx) ++ Compile.javaFxDeps
 
   def server(scalaVersion: String) =
     List(

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -125,9 +125,6 @@ object Deps {
                                javaFxSwing,
                                javaFxWeb)
 
-    val breeze =
-      "org.scalanlp" %% "breeze" % V.breezeV withSources () withJavadoc ()
-
     val breezeViz =
       "org.scalanlp" %% "breeze-viz" % V.breezeV withSources () withJavadoc ()
 

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -126,7 +126,8 @@ object Deps {
                                javaFxWeb)
 
     val breezeViz =
-      "org.scalanlp" %% "breeze-viz" % V.breezeV withSources () withJavadoc ()
+      ("org.scalanlp" %% "breeze-viz" % V.breezeV withSources () withJavadoc ())
+        .exclude("bouncycastle", "bcprov-jdk14")
 
     val playJson =
       "com.typesafe.play" %% "play-json" % V.playv withSources () withJavadoc ()

--- a/testkit/src/main/scala/org/bitcoins/testkit/util/BitcoinSAsyncTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/util/BitcoinSAsyncTest.scala
@@ -231,6 +231,58 @@ trait BaseAsyncTest
         }
     }
   }
+
+  /** Runs all property based tests in parallel. This is a convenient optimization
+    * for synchronous property based tests
+    */
+  def forAllParallel[A, B, C, D](
+      genA: Gen[A],
+      genB: Gen[B],
+      genC: Gen[C],
+      genD: Gen[D])(func: (A, B, C, D) => Assertion): Future[Assertion] = {
+    forAllAsync(genA, genB, genC, genD) {
+      case (inputA, inputB, inputC, inputD) =>
+        Future {
+          func(inputA, inputB, inputC, inputD)
+        }
+    }
+  }
+
+  /** Runs all property based tests in parallel. This is a convenient optimization
+    * for synchronous property based tests
+    */
+  def forAllParallel[A, B, C, D, E](
+      genA: Gen[A],
+      genB: Gen[B],
+      genC: Gen[C],
+      genD: Gen[D],
+      genE: Gen[E])(func: (A, B, C, D, E) => Assertion): Future[Assertion] = {
+    forAllAsync(genA, genB, genC, genD, genE) {
+      case (inputA, inputB, inputC, inputD, inputE) =>
+        Future {
+          func(inputA, inputB, inputC, inputD, inputE)
+        }
+    }
+  }
+
+  /** Runs all property based tests in parallel. This is a convenient optimization
+    * for synchronous property based tests
+    */
+  def forAllParallel[A, B, C, D, E, F](
+      genA: Gen[A],
+      genB: Gen[B],
+      genC: Gen[C],
+      genD: Gen[D],
+      genE: Gen[E],
+      genF: Gen[F])(
+      func: (A, B, C, D, E, F) => Assertion): Future[Assertion] = {
+    forAllAsync(genA, genB, genC, genD, genE, genF) {
+      case (inputA, inputB, inputC, inputD, inputE, inputF) =>
+        Future {
+          func(inputA, inputB, inputC, inputD, inputE, inputF)
+        }
+    }
+  }
 }
 
 /** A trait that uses [[AsyncFlatSpec]] to execute tests

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/DLCWalletUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/DLCWalletUtil.scala
@@ -19,17 +19,21 @@ import org.bitcoins.crypto._
 import org.bitcoins.dlc.testgen.DLCTestUtil
 import org.bitcoins.dlc.wallet.DLCWallet
 import org.bitcoins.dlc.wallet.models._
-import org.bitcoins.testkit.wallet.DLCWalletUtil.InitializedDLCWallet
 import org.bitcoins.testkit.wallet.FundWalletUtil.FundedDLCWallet
 import org.scalatest.Assertions.fail
 import scodec.bits.ByteVector
 
 import scala.concurrent.{ExecutionContext, Future}
 
-trait DLCWalletUtil {
+object DLCWalletUtil {
   lazy val oraclePrivKey: ECPrivateKey = ECPrivateKey.freshPrivateKey
-  lazy val kValue: ECPrivateKey = ECPrivateKey.freshPrivateKey
-  lazy val rValue: SchnorrNonce = kValue.schnorrNonce
+
+  lazy val kValues: Vector[ECPrivateKey] =
+    0.to(10).map(_ => ECPrivateKey.freshPrivateKey).toVector
+  lazy val rValues: Vector[SchnorrNonce] = kValues.map(_.schnorrNonce)
+
+  lazy val kValue: ECPrivateKey = kValues.head
+  lazy val rValue: SchnorrNonce = rValues.head
 
   lazy val winStr: String = "WIN"
   lazy val loseStr: String = "LOSE"
@@ -64,6 +68,18 @@ trait DLCWalletUtil {
 
   lazy val sampleOracleLoseSig: SchnorrDigitalSignature =
     oraclePrivKey.schnorrSignWithNonce(loseHash.bytes, kValue)
+
+  val numDigits: Int = 6
+
+  lazy val multiNonceContractInfo: MultiNonceContractInfo =
+    DLCTestUtil.genMultiDigitContractInfo(numDigits, Satoshis(10000))._1
+
+  lazy val multiNonceOracleInfo: MultiNonceOracleInfo =
+    MultiNonceOracleInfo(oraclePrivKey.schnorrPublicKey,
+                         rValues.take(numDigits))
+
+  lazy val multiNonceOracleAndContractInfo: OracleAndContractInfo =
+    OracleAndContractInfo(multiNonceOracleInfo, multiNonceContractInfo)
 
   lazy val dummyContractMaturity: BlockTimeStamp = BlockTimeStamp(1666335)
   lazy val dummyContractTimeout: BlockTimeStamp = BlockTimeStamp(1666337)
@@ -117,6 +133,9 @@ trait DLCWalletUtil {
     dummyTimeouts
   )
 
+  lazy val sampleMultiNonceDLCOffer: DLCOffer =
+    sampleDLCOffer.copy(oracleAndContractInfo = multiNonceOracleAndContractInfo)
+
   lazy val sampleDLCParamHash: Sha256DigestBE =
     DLCMessage.calcParamHash(sampleOracleInfo,
                              sampleContractInfo,
@@ -153,27 +172,25 @@ trait DLCWalletUtil {
     isInitiator = true,
     account = HDAccount.fromPath(BIP32Path.fromString("m/84'/0'/0'")).get,
     keyIndex = 0,
-    oracleSigOpt = Some(sampleOracleLoseSig),
+    oracleSigsOpt = Some(Vector(sampleOracleLoseSig)),
     fundingOutPointOpt = None,
     fundingTxIdOpt = None,
     closingTxIdOpt = None
   )
 
-  def initDLC(fundedWalletA: FundedDLCWallet, fundedWalletB: FundedDLCWallet)(
-      implicit ec: ExecutionContext): Future[
+  def initDLC(
+      fundedWalletA: FundedDLCWallet,
+      fundedWalletB: FundedDLCWallet,
+      oracleAndContractInfo: OracleAndContractInfo)(implicit
+      ec: ExecutionContext): Future[
     (InitializedDLCWallet, InitializedDLCWallet)] = {
     val walletA = fundedWalletA.wallet
     val walletB = fundedWalletB.wallet
 
-    val numOutcomes = 8
-    val outcomeHashes = DLCTestUtil.genOutcomes(numOutcomes)
-    val (contractInfo, _) =
-      DLCTestUtil.genContractInfos(outcomeHashes, Satoshis(10000))
-
     for {
       offer <- walletA.createDLCOffer(
-        oracleInfo = sampleOracleInfo,
-        contractInfo = contractInfo,
+        oracleInfo = oracleAndContractInfo.oracleInfo,
+        contractInfo = oracleAndContractInfo.offerContractInfo,
         collateral = Satoshis(5000),
         feeRateOpt = None,
         locktime = dummyTimeouts.contractMaturity.toUInt32,
@@ -190,20 +207,9 @@ trait DLCWalletUtil {
        InitializedDLCWallet(FundedDLCWallet(walletB)))
     }
   }
-}
-
-object DLCWalletUtil extends DLCWalletUtil {
 
   case class InitializedDLCWallet(funded: FundedDLCWallet) {
     val wallet: DLCWallet = funded.wallet
-  }
-
-  def createDLCWallets(
-      fundedWalletA: FundedDLCWallet,
-      fundedWalletB: FundedDLCWallet)(implicit ec: ExecutionContext): Future[
-    (InitializedDLCWallet, InitializedDLCWallet)] = {
-
-    initDLC(fundedWalletA, fundedWalletB)
   }
 
   def getInitialOffer(wallet: DLCWallet)(implicit

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/DLCWalletUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/DLCWalletUtil.scala
@@ -175,7 +175,8 @@ object DLCWalletUtil {
     oracleSigsOpt = Some(Vector(sampleOracleLoseSig)),
     fundingOutPointOpt = None,
     fundingTxIdOpt = None,
-    closingTxIdOpt = None
+    closingTxIdOpt = None,
+    outcomeOpt = None
   )
 
   def initDLC(


### PR DESCRIPTION
Needed to hard fork the DLC migrations because we switched to needing to store the pre-images of the outcomes rather than the hashes. 

Some screenshots of gui updates:

![image](https://user-images.githubusercontent.com/15256660/99316432-fe4a8980-2829-11eb-806e-0801bbb7f92d.png)

![image](https://user-images.githubusercontent.com/15256660/99326387-d9601180-283d-11eb-8c22-bcd25f5734f2.png)

![image](https://user-images.githubusercontent.com/15256660/99326421-e977f100-283d-11eb-8cda-39e5877dd49f.png)
